### PR TITLE
Add token for twine release

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -200,13 +200,13 @@ jobs:
           CLEAN: true
 
       # note how we use the PyPI tokens
-      - name: Upload to Azure PyPi (disabled)
+      - name: Upload to PyPi
         run: |
           pip install twine
-          # twine upload --skip-existing ./**/*.whl
+          twine upload --non-interactive --skip-existing ./**/*.whl
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Updates the release workflow with the placeholder for the twine token and enforces noninteractive mode to prevent hangs if something goes wrong.