### PR TITLE
Relax constraints on importlib requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ packages = [
 python = "^3.7"
 
 # Packages for core library
-importlib_metadata = { version = "^1.0", python  = "<3.8" }
+importlib_metadata = { version = ">=1.0", python  = "<3.8" }  # Granta MI STK requires 3.4.0
 requests = "^2.26"
 requests-negotiate-sspi = { version = "^0.5.2", markers = "sys_platform == 'win32'"}
 requests-ntlm = "^1.1.0"


### PR DESCRIPTION
Closes #125 

The Granta MI Python STK has a pinned dependency on importlib_metadata: `importlib_metadata==3.4.0`. This is incompatible with the dependency on importlib_metadata here, which is set to `^1.0`, or `>=1, < 2`.

This PR relaxes the dependency to allow any version greater than the version we require to ensure compatibility with the Granta MI STK and any other packages that may require more specific versions of importlib_metadata.

