### PR TITLE
Rationalise Header Behaviour

### DIFF
--- a/src/ansys/openapi/common/__init__.py
+++ b/src/ansys/openapi/common/__init__.py
@@ -1,5 +1,14 @@
 """Provides a helper to create sessions for use with Ansys OpenAPI clients."""
 
+try:
+    from importlib import metadata as metadata
+
+    __version__ = metadata.version("ansys-openapi-common")
+except ImportError:
+    from importlib_metadata import metadata as metadata_backport
+
+    __version__ = metadata_backport("ansys-openapi-common")["version"]
+
 from ._session import ApiClientFactory, OIDCSessionBuilder
 from ._util import SessionConfiguration, generate_user_agent
 from ._exceptions import ApiConnectionException, ApiException, AuthenticationWarning
@@ -21,12 +30,3 @@ __all__ = [
     "ApiClientBase",
     "ModelBase",
 ]
-
-try:
-    from importlib import metadata as metadata
-
-    __version__ = metadata.version("ansys-openapi-common")
-except ImportError:
-    from importlib_metadata import metadata as metadata_backport
-
-    __version__ = metadata_backport("ansys-openapi-common")["version"]

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -85,8 +85,6 @@ class ApiClient(ApiClientBase):
         self.models: Dict[str, Type[ModelBase]] = {}
         self.api_url = api_url
         self.rest_client = session
-        self.default_headers: CaseInsensitiveDict[str] = CaseInsensitiveDict()
-        self.default_headers["User-Agent"] = "Swagger-Codegen/1.0.0/python"
         self.configuration = configuration
 
     def __repr__(self) -> str:
@@ -111,69 +109,6 @@ class ApiClient(ApiClientBase):
         """
         self.models = models.__dict__
 
-    @property
-    def user_agent(self) -> str:
-        """User agent reported to the API server in the ``User-Agent`` header.
-
-        Some APIs will behave differently for different client applications. Change this if your
-        API requires different behavior.
-
-        Notes
-        -----
-        The behavior of the OpenID Connect login process is not governed by the user-agent string.
-        It is not possible to use a different login flow by changing this value when using OIDC
-        authentication.
-
-        Examples
-        --------
-        >>> client = ApiClient(requests.Session(),
-        ...                    'http://my-api.com/API/v1.svc',
-        ...                    SessionConfiguration())
-        ... client.user_agent
-        'Swagger-Codegen/1.0.0/python'
-
-        Change the user-agent string to impersonate a Mozilla Firefox browser:
-
-        >>> client = ApiClient(requests.Session(),
-        ...                    'http://my-api.com/API/v1.svc',
-        ...                    SessionConfiguration())
-        ... client.user_agent = (
-        ...    'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0'
-        ... )
-        """
-        return self.default_headers["User-Agent"]
-
-    @user_agent.setter
-    def user_agent(self, value: str) -> None:
-        self.default_headers["User-Agent"] = value
-
-    def set_default_header(self, header_name: str, header_value: str) -> None:
-        """Set a default value for a header on all requests.
-
-        Certain headers will be overwritten by the API when sending requests, but default values for others can be set
-        and will be respected. For example, they are set and respected if your API server is configured to require
-        non-OIDC tokens for authentication.
-
-        Notes
-        -----
-        Some headers will always be overwritten, and some may be overwritten, depending on the API endpoint requested.
-        As a guide, the following headers will always be ignored and overwritten:
-
-        * ``Accept``
-        * ``Content-Type``
-
-        The ``Authorization`` header may be overwritten depending on what, if any, authentication scheme is provided for
-        the requests session.
-
-        Examples
-        --------
-        >>> client = ApiClient(requests.Session(),
-        ...                    'http://my-api.com/API/v1.svc',
-        ...                    SessionConfiguration())
-        ... client.set_default_header('Authorization', 'my-token-value')
-        """
-        self.default_headers[header_name] = header_value
-
     def __call_api(
         self,
         resource_path: str,
@@ -193,7 +128,6 @@ class ApiClient(ApiClientBase):
 
         # header parameters
         header_params = header_params or {}
-        header_params.update(self.default_headers)
         if header_params:
             header_params_sanitized = self.sanitize_for_serialization(header_params)
             header_params = dict(

--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -8,6 +8,7 @@ from requests.adapters import HTTPAdapter
 from requests.auth import HTTPBasicAuth
 from requests_ntlm import HttpNtlmAuth  # type: ignore
 
+from . import __version__
 from ._api_client import ApiClient
 from ._util import (
     parse_authenticate,
@@ -84,9 +85,9 @@ class ApiClientFactory:
         logger.info(f"Creating new session at '{api_url}")
 
         if session_configuration is None:
-            from . import __version__
-
             session_configuration = SessionConfiguration()
+
+        if "User-Agent" not in session_configuration.headers:
             user_agent = generate_user_agent("ansys-openapi-common", __version__)
             session_configuration.headers["User-Agent"] = user_agent
         self._session_configuration = session_configuration

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -36,30 +36,6 @@ def test_repr(blank_client):
     assert type(blank_client).__name__ in str(blank_client)
 
 
-def test_default_user_agent(blank_client):
-    assert blank_client.user_agent == "Swagger-Codegen/1.0.0/python"
-
-
-def test_set_user_agent(blank_client):
-    blank_client.user_agent = UA_STRING
-    assert blank_client.user_agent == UA_STRING
-    assert blank_client.default_headers["User-Agent"] == UA_STRING
-
-
-def test_default_default_headers(blank_client):
-    assert len(blank_client.default_headers) == 1
-    assert "User-Agent" in blank_client.default_headers.keys()
-
-
-def test_set_default_header(blank_client):
-    test_header_value = secrets.token_hex(8)
-    test_header_name = secrets.token_hex(8)
-    assert test_header_name not in blank_client.default_headers
-    blank_client.set_default_header(test_header_name, test_header_value)
-    assert test_header_name in blank_client.default_headers
-    assert blank_client.default_headers[test_header_name.upper()] == test_header_value
-
-
 class TestSerialization:
     _test_value_list = ["foo", int(2), 2.0, True]
     _test_value_types = [str, int, float, bool]


### PR DESCRIPTION
Remove api_client's header interface, rely on SessionConfiguration

- Remove header related properties
- Create default session configuration if absent
- Add default user-agent if missing
- Remove tests for removed properties