### PR TITLE
Ensure OIDC Callback Server releases bound TCP port

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ requests-mock = { version = "*", optional = true }
 pytest-mock = { version = "*", optional = true }
 covertable = { version = "*", optional = true }
 asgi_gssapi = { version = "*", markers = "sys_platform == 'linux'", optional = true }
+psutil = {version = "*", optional = true}
 
 # Doc packages
 pyansys-sphinx-theme = { version = "0.2.2", optional = true }
@@ -91,7 +92,8 @@ test = [
   "requests-mock",
   "pytest-mock",
   "covertable",
-  "asgi_gssapi"
+  "asgi_gssapi",
+  "psutil",
 ]
 
 doc = [

--- a/src/ansys/openapi/common/_oidc.py
+++ b/src/ansys/openapi/common/_oidc.py
@@ -218,14 +218,16 @@ class OIDCSessionFactory:
         Returns
         -------
         str
-            The url of the callback request, which contains the authentication code.
+            The url of the callback request. The url contains the authentication code as a parameter.
         """
 
         self._callback_server.timeout = login_timeout
         self._callback_server.handle_request()
         auth_code = self._callback_server.auth_code
         if not auth_code:
-            raise ValueError("No authorization code returned by OpenID Connect identity provider.")
+            raise ValueError(
+                "No authorization code returned by OpenID Connect identity provider."
+            )
         del (  # Ensures bound port is released for subsequent OpenID Connect authentication sessions
             self._callback_server
         )

--- a/src/ansys/openapi/common/_oidc.py
+++ b/src/ansys/openapi/common/_oidc.py
@@ -224,6 +224,8 @@ class OIDCSessionFactory:
         self._callback_server.timeout = login_timeout
         self._callback_server.handle_request()
         auth_code = self._callback_server.auth_code
+        if not auth_code:
+            raise ValueError("No authorization code returned by OIDC server.")
         del (
             self._callback_server
         )  # Ensures bound port is released for subsequent OIDC connections

--- a/src/ansys/openapi/common/_oidc.py
+++ b/src/ansys/openapi/common/_oidc.py
@@ -224,7 +224,9 @@ class OIDCSessionFactory:
         self._callback_server.timeout = login_timeout
         self._callback_server.handle_request()
         auth_code = self._callback_server.auth_code
-        del self._callback_server  # Ensures bound port is released for subsequent OIDC connections
+        del (
+            self._callback_server
+        )  # Ensures bound port is released for subsequent OIDC connections
         return auth_code
 
     def _configure_token_refresh(self) -> None:

--- a/src/ansys/openapi/common/_oidc.py
+++ b/src/ansys/openapi/common/_oidc.py
@@ -208,7 +208,7 @@ class OIDCSessionFactory:
         return self._oauth_session
 
     def _get_auth_code(self, login_timeout: int) -> str:
-        """Receive the callback request from the OIDC identity provider.
+        """Receive the callback request from the OpenID Connect identity provider.
 
         Parameters
         ----------
@@ -225,10 +225,10 @@ class OIDCSessionFactory:
         self._callback_server.handle_request()
         auth_code = self._callback_server.auth_code
         if not auth_code:
-            raise ValueError("No authorization code returned by OIDC server.")
-        del (
+            raise ValueError("No authorization code returned by OpenID Connect identity provider.")
+        del (  # Ensures bound port is released for subsequent OpenID Connect authentication sessions
             self._callback_server
-        )  # Ensures bound port is released for subsequent OIDC connections
+        )
         return auth_code
 
     def _configure_token_refresh(self) -> None:

--- a/src/ansys/openapi/common/_util.py
+++ b/src/ansys/openapi/common/_util.py
@@ -226,7 +226,7 @@ class OIDCCallbackHTTPServer(HTTPServer):
     ----------
     auth_code : str, optional
         Authentication code received from the user's browser when authentication completes.
-        The default is ``None`` when the auth_code has not yet been received.
+        The default is ``None`` when the ``auth_code`` has not yet been received.
     """
 
     def __init__(self) -> None:

--- a/src/ansys/openapi/common/_util.py
+++ b/src/ansys/openapi/common/_util.py
@@ -212,13 +212,11 @@ class ResponseHandler(BaseHTTPRequestHandler):
     # noinspection PyPep8Naming
     def do_GET(self) -> None:
         """Handle GET requests to the callback URL."""
+        self.server.auth_code = "https://localhost{}".format(self.path)  # type: ignore[attr-defined]
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")
         self.end_headers()
-
         self.wfile.write(self._response_html)
-        # noinspection PyProtectedMember
-        self.server._auth_code.put("https://localhost{}".format(self.path))  # type: ignore[attr-defined]
 
 
 class OIDCCallbackHTTPServer(HTTPServer):
@@ -226,21 +224,14 @@ class OIDCCallbackHTTPServer(HTTPServer):
 
     Attributes
     ----------
-    _auth_code : Queue
-        Store for authentication code received from the user's browser when authentication completes.
+    auth_code : str, optional
+        Authentication code received from the user's browser when authentication completes.
+        The default is ``None`` when the auth_code has not yet been received.
     """
 
     def __init__(self) -> None:
-        from queue import Queue
-
         super().__init__(("", 32284), ResponseHandler)
-        self._auth_code: Queue = Queue()
-
-    async def get_auth_code(self) -> Any:
-        return self._auth_code.get(block=True)
-
-    def __del__(self) -> None:
-        self.server_close()
+        self.auth_code: Optional[str] = None
 
 
 class RequestsConfiguration(TypedDict):

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -136,7 +136,9 @@ class TestOIDCHTTPServer:
         assert test_code in oidc_callback_server.auth_code
 
 
-def test_oidc_callback_server_port_acquisition_and_release(oidc_callback_server_process):
+def test_oidc_callback_server_port_acquisition_and_release(
+    oidc_callback_server_process,
+):
     # Check that the process is bound to the OIDC callback port
     proc = psutil.Process(oidc_callback_server_process.pid)
     assert any([conn.laddr.port == 32284 for conn in proc.connections()])

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -97,7 +97,7 @@ def run_server():
 
 @pytest.fixture(scope="function")
 def oidc_callback_server_process():
-    # Run the OIDC callback server in a process, and return the process
+    # Run the OpenID Connect callback server in a process and return the process
     # Doesn't perform any cleanup, so p.terminate() must be called by the test
     p = Process(target=run_server, daemon=True)
     p.start()
@@ -108,7 +108,7 @@ def oidc_callback_server_process():
 
 @pytest.fixture(scope="function")
 def oidc_callback_server():
-    # Run the OIDC callback server in a thread, and return the server
+    # Run the OpenID Connect callback server in a thread and return the server
     # Clean up when finished
     callback_server = OIDCCallbackHTTPServer()
     thread = threading.Thread(target=callback_server.handle_request)
@@ -139,14 +139,14 @@ class TestOIDCHTTPServer:
 def test_oidc_callback_server_port_acquisition_and_release(
     oidc_callback_server_process,
 ):
-    # Check that the process is bound to the OIDC callback port
+    # Check that the process is bound to the OpenID Connect callback port
     proc = psutil.Process(oidc_callback_server_process.pid)
     assert any([conn.laddr.port == 32284 for conn in proc.connections()])
 
-    # Send the request that will cause the server to close
+    # Send a request that will cause the server to close
     requests.get("http://localhost:32284?code=1234567890")
 
-    # Check that the process is no longer bound to the OIDC callback port
+    # Check that the process is no longer bound to the OpenID Connect callback port
     connections = proc.connections(kind="tcp")
     for conn in connections:
         print(conn.laddr)


### PR DESCRIPTION
Closes #137 

The OIDCCallbackHTTPServer wasn't correctly releasing TCP port 32284. This caused problems if we tried to authenticate to a second OIDC server in the same script, e.g. by using the STK.

This PR re-works the OIDCCallbackHTTPServer implementation to use `handle_request()` instead of `serve_forever()`, which seems to eliminate the need to run the server in a separate thread. Instead, we now synchronously wait the `login_timeout` length of time for the server to handle a request. If it does, we return the auth_code.

I have also added tests that check the status of the TCP port both when the server is running and when it has been closed.