### PR TITLE
Fix flaky OIDC test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ deps =
     .[oidc]
     .[linux-kerberos]
     .[test]
-commands = pytest --cov=ansys.openapi.common --cov-report=xml ./tests {posargs}
+commands = pytest --cov=ansys.openapi.common --cov-report=xml {posargs}
 
 [testenv:lint]
 deps =
@@ -153,4 +153,9 @@ show_error_codes = true
 [tool.coverage.run]
 omit = [
   "**/_base/*"
+]
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
 ]

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -3,6 +3,7 @@ import threading
 import psutil
 import time
 from multiprocessing import Process
+import os
 
 import pytest
 import requests
@@ -95,23 +96,30 @@ def run_server():
     callback_server.handle_request()
 
 
+def check_port_binding(pid):
+    # Wait for the process to start up and bind to the port before returning
+    port_bound = False
+    attempts = 0
+    while not port_bound:
+        time.sleep(5)
+        proc = psutil.Process(pid)
+        port_bound = any([conn.laddr.port == 32284 for conn in proc.connections()])
+        attempts = attempts + 1
+        if attempts == 5:
+            pid.terminate()
+            # Additional debugging
+            netstat_output = os.popen("netstat -p -at").readlines()
+            print("".join(netstat_output))
+            raise RuntimeError("OIDCCallbackHTTPServer failed to bind to port 32284")
+
+
 @pytest.fixture(scope="function")
 def oidc_callback_server_process():
     # Run the OpenID Connect callback server in a process and return the process
     # Doesn't perform any cleanup, so p.terminate() must be called by the test
     p = Process(target=run_server, daemon=True)
     p.start()
-
-    # Wait for the process to start up and bind to the port before returning
-    port_bound = False
-    attempts = 0
-    proc = psutil.Process(p.pid)
-    while not port_bound:
-        time.sleep(5)
-        port_bound = any([conn.laddr.port == 32284 for conn in proc.connections()])
-        attempts = attempts + 1
-        if attempts == 5:
-            raise RuntimeError("OIDCCallbackHTTPServer failed to bind to port 32284")
+    check_port_binding(p.pid)
     return p
 
 
@@ -123,6 +131,7 @@ def oidc_callback_server():
     thread = threading.Thread(target=callback_server.handle_request)
     thread.daemon = True
     thread.start()
+    check_port_binding(os.getpid())
     yield callback_server
     del callback_server
     del thread


### PR DESCRIPTION
Closes #141 

This PR checks that an OIDC callback server is running and bound to the required port before proceeding with tests. This fixes an intermittent issue where a test to check the port was bound would fail if the server hadn't start.

This change in effect allows multiple attempts to check that the port is bound. However, it still requires that the port release happens strictly sequentially after the request is made, which is the most important part of the test.