### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -156,20 +156,6 @@ jobs:
           name: Documentation-pdf
           path: doc/build/latex/*.pdf
           retention-days: 7
-          
-  TestArtifact:
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: ansys-grantami-common-wheel
-          path: dist
-      - name: List directory contents
-        run: |
-          ls -la
-          ls ./**/*.whl
 
   Release:
     if: contains(github.ref, 'refs/tags')
@@ -194,10 +180,12 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: ansys-grantami-common-wheel
+          path: ~/dist
 
       - uses: actions/download-artifact@v2
         with:
           name: Documentation-pdf
+          path: ~/pdf
 
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -161,12 +161,15 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: ansys-grantami-common-wheel
       - name: List directory contents
         run: |
           ls -la
+          ls ./*.whl
+          ls ./**/*.whl
 
   Release:
     if: contains(github.ref, 'refs/tags')

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -156,6 +156,17 @@ jobs:
           name: Documentation-pdf
           path: doc/build/latex/*.pdf
           retention-days: 7
+          
+  TestArtifact:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: ansys-grantami-common-wheel
+      - name: List directory contents
+        run: |
+          ls -la
 
   Release:
     if: contains(github.ref, 'refs/tags')

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -165,10 +165,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: ansys-grantami-common-wheel
+          path: dist
       - name: List directory contents
         run: |
           ls -la
-          ls ./*.whl
           ls ./**/*.whl
 
   Release:


### PR DESCRIPTION
The workflow previously downloaded the pdf documentation and wheel file into `~/`. The twine release step tries to find a wheel with the glob `~/**/*.whl` which matches any wheel in any subdirectory. It was not matching.