### PR TITLE
Fix missing OIDC components exception message

### DIFF
--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -283,7 +283,7 @@ class ApiClientFactory:
         """
         if not _oidc_enabled:
             raise ImportError(
-                "OpenID Connect features are not enabled. To use them, run `pip install openapi-client-common[oidc]`."
+                "OpenID Connect features are not enabled. To use them, run `pip install ansys-openapi-common[oidc]`."
             )
         initial_response = self._session.get(self._api_url)
         if self.__handle_initial_response(initial_response):

--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -241,7 +241,7 @@ class ApiClientFactory:
         """
         if not (_platform_windows or _linux_kerberos_enabled):
             raise ImportError(
-                "Kerberos is not enabled. To use it, run `pip install openapi-client-common[linux-kerberos]`."
+                "Kerberos is not enabled. To use it, run `pip install ansys-openapi-common[linux-kerberos]`."
             )
         initial_response = self._session.get(self._api_url)
         if self.__handle_initial_response(initial_response):

--- a/tests/test_missing_imports.py
+++ b/tests/test_missing_imports.py
@@ -9,11 +9,12 @@ init_modules = []
 
 def get_package_name() -> str:
     import ansys.openapi.common
+
     try:
         from importlib.metadata import metadata
     except ImportError:  # Python 3.7
         from importlib_metadata import metadata
-    return metadata(ansys.openapi.common.__name__)['Name']
+    return metadata(ansys.openapi.common.__name__)["Name"]
 
 
 class TestMissingExtras:
@@ -57,6 +58,4 @@ class TestMissingExtras:
             _ = ApiClientFactory("http://www.my-api.com/v1.svc").with_autologon()
 
         package_name = get_package_name()
-        assert f"`pip install {package_name}[linux-kerberos]`" in str(
-            excinfo.value
-        )
+        assert f"`pip install {package_name}[linux-kerberos]`" in str(excinfo.value)

--- a/tests/test_missing_imports.py
+++ b/tests/test_missing_imports.py
@@ -7,6 +7,15 @@ import sys
 init_modules = []
 
 
+def get_package_name() -> str:
+    import ansys.openapi.common
+    try:
+        from importlib.metadata import metadata
+    except ImportError:  # Python 3.7
+        from importlib_metadata import metadata
+    return metadata(ansys.openapi.common.__name__)['Name']
+
+
 class TestMissingExtras:
     real_import = __import__
     blocked_import = ""
@@ -34,7 +43,8 @@ class TestMissingExtras:
         with pytest.raises(ImportError) as excinfo:
             _ = ApiClientFactory("http://www.my-api.com/v1.svc").with_oidc()
 
-        assert "`pip install openapi-client-common[oidc]`" in str(excinfo.value)
+        package_name = get_package_name()
+        assert f"`pip install {package_name}[oidc]`" in str(excinfo.value)
 
     @pytest.mark.skipif(os.name == "nt", reason="Test only applies to linux")
     def test_create_autologon_on_linux_with_no_extra_throws(self, mocker):
@@ -46,6 +56,7 @@ class TestMissingExtras:
         with pytest.raises(ImportError) as excinfo:
             _ = ApiClientFactory("http://www.my-api.com/v1.svc").with_autologon()
 
-        assert "`pip install openapi-client-common[linux-kerberos]`" in str(
+        package_name = get_package_name()
+        assert f"`pip install {package_name}[linux-kerberos]`" in str(
             excinfo.value
         )


### PR DESCRIPTION
Closes #145 

Changes the name of the package in the pip command. The text can now be copied as-is to the command line to install the necessary packages. I have also fixed the similar linux-kerberos exception text.