### PR TITLE
[CI]156 - Add generate_release_notes to release action

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -251,6 +251,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
+          generate_release_notes: true
           files: |
             ./**/*.whl
             ./**/*.zip


### PR DESCRIPTION
Closes #156 

Add the generate_release_notes flag to the release action to automatically add release notes