### PR TITLE
Remove sonarcloud analysis

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -80,55 +80,12 @@ jobs:
     - name: Test with tox
       run: tox -- --with-kerberos
       
-    - name: Remove platform-specific paths and append platform to coverage file name
-      run: |
-        sed -i 's/\.tox\/py[0-9]\+\/lib\/python3\.[0-9]\+\/site-packages/src/g' coverage.xml
-        sed -i 's/\.tox\.py3[0-9]\+\.lib\.python3\.[0-9]\+\.site-packages\.//g' coverage.xml
-        mv ./coverage.xml ./coverage.${{ matrix.python-version }}.xml
-
-    - name: Store coverage data
-      uses: actions/upload-artifact@v2
+    - name: Upload coverage report
+      uses: codecov/codecov-action@v2
+      if: ${{ github.actor != 'dependabot[bot]' }}
       with:
-        name: coverage-${{ matrix.python-version }}
-        path: ./coverage*.xml
-        retention-days: 1
-
-  sonarcloud:
-    name: SonarCloud scan
-    runs-on: ubuntu-latest
-    needs: [test]
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 0
-        
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
-    
-    - uses: actions/download-artifact@v2
-      with:
-        path: coverage-reports
-        
-    - name: List coverage reports
-      run: |
-        cp coverage-reports/**/coverage*.xml ./
-        
-    - name: SonarCloud Scan
-      uses: SonarSource/sonarcloud-github-action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      with:
-        args: >
-          -Dsonar.organization=pyansys-test
-          -Dsonar.projectKey=pyansys-test-openapi-common
-          -Dsonar.python.version=3
-          -Dsonar.sources=src
-          -Dsonar.python.coverage.reportPaths=coverage*.xml
-          -Dsonar.core.codeCoveragePlugin=cobertura
-          -Dsonar.dynamicAnalysis=reuseReports
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     name: Build


### PR DESCRIPTION
This PR removes the SonarCloud analysis step from the build and test workflow. It duplicates the org-level analysis recently setup.