### PR TITLE
171 - Fix path parameter format

### DIFF
--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -136,27 +136,12 @@ class ApiClient(ApiClientBase):
 
         # path parameters
         if path_params:
-            path_params_sanitized = self.sanitize_for_serialization(path_params)
-            path_params_tuples = self.parameters_to_tuples(
-                path_params_sanitized, collection_formats
-            )
-            for k, v in path_params_tuples:
-                # specified safe chars, encode everything
-                resource_path = resource_path.replace(
-                    f"{k}",
-                    quote(str(v), safe=self.configuration.safe_chars_for_path_param),
-                )
+            resource_path = self.__handle_path_params(resource_path, path_params, collection_formats)
 
         # query parameters
         query_params_str = ""
         if query_params:
-            query_params_sanitized = self.sanitize_for_serialization(query_params)
-            query_params_tuples = self.parameters_to_tuples(
-                query_params_sanitized, collection_formats
-            )
-            query_params_str = "&".join(
-                ["=".join(param) for param in query_params_tuples]
-            )
+            query_params_str = self.__handle_query_params(query_params, collection_formats)
 
         # post parameters
         if post_params or files:
@@ -199,6 +184,26 @@ class ApiClient(ApiClientBase):
             return return_data
         else:
             return return_data, response_data.status_code, response_data.headers
+
+    def __handle_path_params(self, resource_path: str, path_params: Union[Dict[str, Union[str, int]], List[Tuple], None], collection_formats: Optional[Dict[str, str]]) -> str:
+        path_params_sanitized = self.sanitize_for_serialization(path_params)
+        path_params_tuples = self.parameters_to_tuples(
+            path_params_sanitized, collection_formats
+        )
+        for k, v in path_params_tuples:
+            # specified safe chars, encode everything
+            resource_path = resource_path.replace(
+                f"{{{k}}}",
+                quote(str(v), safe=self.configuration.safe_chars_for_path_param),
+            )
+        return resource_path
+
+    def __handle_query_params(self, query_params: Union[Dict[str, Union[str, int]], List[Tuple], None], collection_formats: Optional[Dict[str, str]]) -> str:
+        query_params_sanitized = self.sanitize_for_serialization(query_params)
+        query_params_tuples = self.parameters_to_tuples(
+            query_params_sanitized, collection_formats
+        )
+        return "&".join(["=".join(param) for param in query_params_tuples])
 
     def sanitize_for_serialization(self, obj: Any) -> Any:
         """Build a JSON POST object.

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -136,12 +136,16 @@ class ApiClient(ApiClientBase):
 
         # path parameters
         if path_params:
-            resource_path = self.__handle_path_params(resource_path, path_params, collection_formats)
+            resource_path = self.__handle_path_params(
+                resource_path, path_params, collection_formats
+            )
 
         # query parameters
         query_params_str = ""
         if query_params:
-            query_params_str = self.__handle_query_params(query_params, collection_formats)
+            query_params_str = self.__handle_query_params(
+                query_params, collection_formats
+            )
 
         # post parameters
         if post_params or files:
@@ -185,7 +189,12 @@ class ApiClient(ApiClientBase):
         else:
             return return_data, response_data.status_code, response_data.headers
 
-    def __handle_path_params(self, resource_path: str, path_params: Union[Dict[str, Union[str, int]], List[Tuple], None], collection_formats: Optional[Dict[str, str]]) -> str:
+    def __handle_path_params(
+        self,
+        resource_path: str,
+        path_params: Union[Dict[str, Union[str, int]], List[Tuple], None],
+        collection_formats: Optional[Dict[str, str]],
+    ) -> str:
         path_params_sanitized = self.sanitize_for_serialization(path_params)
         path_params_tuples = self.parameters_to_tuples(
             path_params_sanitized, collection_formats
@@ -198,7 +207,11 @@ class ApiClient(ApiClientBase):
             )
         return resource_path
 
-    def __handle_query_params(self, query_params: Union[Dict[str, Union[str, int]], List[Tuple], None], collection_formats: Optional[Dict[str, str]]) -> str:
+    def __handle_query_params(
+        self,
+        query_params: Union[Dict[str, Union[str, int]], List[Tuple], None],
+        collection_formats: Optional[Dict[str, str]],
+    ) -> str:
         query_params_sanitized = self.sanitize_for_serialization(query_params)
         query_params_tuples = self.parameters_to_tuples(
             query_params_sanitized, collection_formats

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -44,27 +44,35 @@ class TestParameterHandling:
     def test_simple_path_rewrite(self):
         id_ = str(uuid.uuid4())
         single_path = "/resource/{id}"
-        result = self._client._ApiClient__handle_path_params(single_path, {"id": id_}, None)
+        result = self._client._ApiClient__handle_path_params(
+            single_path, {"id": id_}, None
+        )
         assert single_path.replace("{id}", id_) == result
 
     def test_multiple_path_rewrites(self):
         id_ = str(uuid.uuid4())
         name = "TestResource"
         multiple_path = "/resource/{id}/name/{name}"
-        result = self._client._ApiClient__handle_path_params(multiple_path, {"id": id_, "name": name}, None)
+        result = self._client._ApiClient__handle_path_params(
+            multiple_path, {"id": id_, "name": name}, None
+        )
         assert multiple_path.replace("{id}", id_).replace("{name}", name) == result
 
     def test_path_with_naughty_characters(self):
-        name = "\"Na,ughty!P,ath."
+        name = '"Na,ughty!P,ath.'
         naughty_path = "/resource/{name}"
-        result = self._client._ApiClient__handle_path_params(naughty_path, {"name": name}, None)
+        result = self._client._ApiClient__handle_path_params(
+            naughty_path, {"name": name}, None
+        )
         assert "/resource/%22Na%2Cughty%21P%2Cath." == result
 
     def test_path_with_naughty_characters_allowed(self):
         name = "<SpecialName>"
         naughty_path = "/resource/{name}"
         self._client.configuration.safe_chars_for_path_param = "<>"
-        result = self._client._ApiClient__handle_path_params(naughty_path, {"name": name}, None)
+        result = self._client._ApiClient__handle_path_params(
+            naughty_path, {"name": name}, None
+        )
         assert "/resource/<SpecialName>" == result
 
     def test_single_query(self):
@@ -83,9 +91,9 @@ class TestParameterHandling:
         assert "bird=swallow&type=african|european" == result
 
     def test_query_with_naughty_characters(self):
-        query = {"search": "\"A &Naughty#Qu,ery@100%"}
+        query = {"search": '"A &Naughty#Qu,ery@100%'}
         result = self._client._ApiClient__handle_query_params(query, None)
-        assert "search=\"A &Naughty#Qu,ery@100%" == result
+        assert 'search="A &Naughty#Qu,ery@100%' == result
 
 
 class TestSerialization:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -655,7 +655,7 @@ class TestResponseHandling:
             json_obj = json.loads(json_body)
             return json_obj == expected_request
 
-        resource_path = "/models/ID"
+        resource_path = "/models/{ID}"
         method = "PATCH"
         record_id = str(uuid.uuid4())
         path_params = {"ID": record_id}

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -36,6 +36,58 @@ def test_repr(blank_client):
     assert type(blank_client).__name__ in str(blank_client)
 
 
+class TestParameterHandling:
+    @pytest.fixture(autouse=True)
+    def _blank_client(self, blank_client):
+        self._client = blank_client
+
+    def test_simple_path_rewrite(self):
+        id_ = str(uuid.uuid4())
+        single_path = "/resource/{id}"
+        result = self._client._ApiClient__handle_path_params(single_path, {"id": id_}, None)
+        assert single_path.replace("{id}", id_) == result
+
+    def test_multiple_path_rewrites(self):
+        id_ = str(uuid.uuid4())
+        name = "TestResource"
+        multiple_path = "/resource/{id}/name/{name}"
+        result = self._client._ApiClient__handle_path_params(multiple_path, {"id": id_, "name": name}, None)
+        assert multiple_path.replace("{id}", id_).replace("{name}", name) == result
+
+    def test_path_with_naughty_characters(self):
+        name = "\"Na,ughty!P,ath."
+        naughty_path = "/resource/{name}"
+        result = self._client._ApiClient__handle_path_params(naughty_path, {"name": name}, None)
+        assert "/resource/%22Na%2Cughty%21P%2Cath." == result
+
+    def test_path_with_naughty_characters_allowed(self):
+        name = "<SpecialName>"
+        naughty_path = "/resource/{name}"
+        self._client.configuration.safe_chars_for_path_param = "<>"
+        result = self._client._ApiClient__handle_path_params(naughty_path, {"name": name}, None)
+        assert "/resource/<SpecialName>" == result
+
+    def test_single_query(self):
+        query = {"name": "Spamalot"}
+        result = self._client._ApiClient__handle_query_params(query, None)
+        assert "name=Spamalot" == result
+
+    def test_multiple_queries(self):
+        query = {"bird": "swallow", "type": "african"}
+        result = self._client._ApiClient__handle_query_params(query, None)
+        assert "bird=swallow&type=african" == result
+
+    def test_simple_query_with_collection(self):
+        query = {"bird": "swallow", "type": ("african", "european")}
+        result = self._client._ApiClient__handle_query_params(query, {"type": "pipes"})
+        assert "bird=swallow&type=african|european" == result
+
+    def test_query_with_naughty_characters(self):
+        query = {"search": "\"A &Naughty#Qu,ery@100%"}
+        result = self._client._ApiClient__handle_query_params(query, None)
+        assert "search=\"A &Naughty#Qu,ery@100%" == result
+
+
 class TestSerialization:
     _test_value_list = ["foo", int(2), 2.0, True]
     _test_value_types = [str, int, float, bool]

--- a/tests/test_integration_anonymous.py
+++ b/tests/test_integration_anonymous.py
@@ -57,7 +57,7 @@ class TestAnonymous:
             bool_property=False,
         )
 
-        resource_path = "/models/ID"
+        resource_path = "/models/{ID}"
         method = "PATCH"
         path_params = {"ID": TEST_MODEL_ID}
 

--- a/tests/test_integration_basic.py
+++ b/tests/test_integration_basic.py
@@ -92,7 +92,7 @@ class TestBasic:
             bool_property=False,
         )
 
-        resource_path = "/models/ID"
+        resource_path = "/models/{ID}"
         method = "PATCH"
         path_params = {"ID": TEST_MODEL_ID}
 

--- a/tests/test_integration_negotiate.py
+++ b/tests/test_integration_negotiate.py
@@ -89,7 +89,7 @@ class TestNegotiate:
             bool_property=False,
         )
 
-        resource_path = "/models/ID"
+        resource_path = "/models/{ID}"
         method = "PATCH"
         path_params = {"ID": TEST_MODEL_ID}
 


### PR DESCRIPTION
Closes #171 

Accompanying code generator generates path parameters with placeholder values like `http://api.com/resource/{param}`, this was being incorrectly handled, resulting in invalid resources.

This PR is some minor refactoring to improve testability, adding some tests for path and query parameter construction, and the fix for the underlying issue.