### PR TITLE
170 - Respect response_type when Deserializing response

### DIFF
--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -325,13 +325,7 @@ class ApiClient(ApiClientBase):
             try:
                 data = response.json()
             except ValueError:
-                content_type = response.headers.get(
-                    "Content-Type", "application/octet-stream"
-                )
-                if content_type not in ["application/octet-stream"]:
-                    data = response.text
-                else:
-                    data = response.content
+                data = response.content
 
         return self.__deserialize(data, response_type)
 

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -319,16 +319,19 @@ class ApiClient(ApiClientBase):
         if response_type == "file":
             return self.__deserialize_file(response)
 
-        try:
-            data = response.json()
-        except ValueError:
-            content_type = response.headers.get(
-                "Content-Type", "application/octet-stream"
-            )
-            if content_type not in ["application/octet-stream"]:
-                data = response.text
-            else:
-                data = response.content
+        if response_type == "str":
+            data = response.text
+        else:
+            try:
+                data = response.json()
+            except ValueError:
+                content_type = response.headers.get(
+                    "Content-Type", "application/octet-stream"
+                )
+                if content_type not in ["application/octet-stream"]:
+                    data = response.text
+                else:
+                    data = response.content
 
         return self.__deserialize(data, response_type)
 

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -320,7 +320,7 @@ class ApiClient(ApiClientBase):
             return self.__deserialize_file(response)
 
         if response_type == "str":
-            data = response.text
+            data: SerializedType = response.text
         else:
             try:
                 data = response.json()

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -378,12 +378,21 @@ class TestResponseParsing:
         response = self.create_response(data)
         deserialize_mock = mocker.patch.object(ApiClient, "_ApiClient__deserialize")
         deserialize_mock.return_value = True
-        _ = self._client.deserialize(response, dict)
+        _ = self._client.deserialize(response, "dict")
         deserialize_mock.assert_called()
-        deserialize_mock.assert_called_once_with(data, dict)
+        deserialize_mock.assert_called_once_with(data, "dict")
 
     def test_text_parsed_as_text(self, mocker):
         data = "This is some data this is definitely not json, it should be rendered as a string"
+        response = self.create_response(text=data, content_type="text/plain")
+        deserialize_mock = mocker.patch.object(ApiClient, "_ApiClient__deserialize")
+        deserialize_mock.return_value = True
+        _ = self._client.deserialize(response, "str")
+        deserialize_mock.assert_called()
+        deserialize_mock.assert_called_once_with(data, "str")
+
+    def test_deserialize_json_as_string_returns_string(self, mocker):
+        data = json.dumps({"foo": "bar", "baz": [1, 2, 3]})
         response = self.create_response(text=data, content_type="text/plain")
         deserialize_mock = mocker.patch.object(ApiClient, "_ApiClient__deserialize")
         deserialize_mock.return_value = True


### PR DESCRIPTION
Closes #170 

This PR treats response data as a string if it's specified as str, even if it looks like json.

Sometimes APIs will return stringified json, currently this will throw when we attempt to deserialize it, since we will end up expecting a string but we will receive a dictionary. This PR makes response_type override the existing logic, so that this use case is supported.