### PR TITLE
FIX - Make explicit which imports are expected on each version

### DIFF
--- a/src/ansys/openapi/common/__init__.py
+++ b/src/ansys/openapi/common/__init__.py
@@ -1,10 +1,11 @@
 """Provides a helper to create sessions for use with Ansys OpenAPI clients."""
+import sys
 
-try:
+if sys.version_info >= (3, 8):
     from importlib import metadata as metadata
 
     __version__ = metadata.version("ansys-openapi-common")
-except ImportError:
+else:
     from importlib_metadata import metadata as metadata_backport
 
     __version__ = metadata_backport("ansys-openapi-common")["version"]

--- a/src/ansys/openapi/common/_util.py
+++ b/src/ansys/openapi/common/_util.py
@@ -1,4 +1,5 @@
 import http.cookiejar
+import sys
 
 import pyparsing as pp
 from collections import OrderedDict
@@ -11,9 +12,9 @@ from pyparsing import Word
 from ._exceptions import ApiException
 from ._logger import logger
 
-try:
+if sys.version_info >= (3, 8):
     from typing import TypedDict
-except ImportError:
+else:
     from typing_extensions import TypedDict, Type
 
 import tempfile


### PR DESCRIPTION
MYPY gets quite confused when we need to import packages conditionally, for example importlib-metadata backport for python 3.7. If we specify a version switch, rather than trying and excepting on the ImportError then MYPY is intelligent enough to not verify typings for branches that cannot be hit.

This PR should fix the issue with the Keyring Dependabot PR, and hopefully should stop the ping-pong adding a removing the ignore flag in `__init__.py`