### PR TITLE
Add language to conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -78,7 +78,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
This PR adds the language tag to conf.py. Absence of this will be a warning in sphinx 5, which will cause doc build failures (see https://github.com/pyansys/openapi-common/actions/runs/2859407707)