### PR TITLE
CI - Use explicit extras syntax for tox-poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,10 +117,11 @@ python =
     3.10: py310
 
 [testenv]
-deps =
-    .[oidc]
-    .[linux-kerberos]
-    .[test]
+deps = pytest
+extras = 
+    test
+    oidc
+    linux-kerberos
 commands = pytest --cov=ansys.openapi.common --cov-report=xml {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
Build is currently broken, I'm not sure exactly why, but the behaviour of the `poetry install` command changed, and it looks like we were relying on some unsupported functionality.

The `[testenv].extras` property is supported correctly in tox and this appears to fix the issue locally.