### PR TITLE
#284 - Convert Query Params to Strings

### DIFF
--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -216,7 +216,7 @@ class ApiClient(ApiClientBase):
         query_params_tuples = self.parameters_to_tuples(
             query_params_sanitized, collection_formats
         )
-        return "&".join(["=".join((str(k), str(v))) for k, v in query_params_tuples])
+        return "&".join([f"{k}={v}" for k, v in query_params_tuples])
 
     def sanitize_for_serialization(self, obj: Any) -> Any:
         """Build a JSON POST object.

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -216,7 +216,7 @@ class ApiClient(ApiClientBase):
         query_params_tuples = self.parameters_to_tuples(
             query_params_sanitized, collection_formats
         )
-        return "&".join(["=".join(param) for param in query_params_tuples])
+        return "&".join(["=".join((str(k), str(v))) for k, v in query_params_tuples])
 
     def sanitize_for_serialization(self, obj: Any) -> Any:
         """Build a JSON POST object.

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -80,10 +80,20 @@ class TestParameterHandling:
         result = self._client._ApiClient__handle_query_params(query, None)
         assert "name=Spamalot" == result
 
+    def test_single_query_with_int(self):
+        query = {"count": 0}
+        result = self._client._ApiClient__handle_query_params(query, None)
+        assert "count=0" == result
+
     def test_multiple_queries(self):
         query = {"bird": "swallow", "type": "african"}
         result = self._client._ApiClient__handle_query_params(query, None)
         assert "bird=swallow&type=african" == result
+
+    def test_multiple_queries_with_ints(self):
+        query = {"start": 0, "finish": 10}
+        result = self._client._ApiClient__handle_query_params(query, None)
+        assert "start=0&finish=10" == result
 
     def test_simple_query_with_collection(self):
         query = {"bird": "swallow", "type": ("african", "european")}


### PR DESCRIPTION
Closes #284 

This PR ensures that query parameters are converted to strings before we try to concatentate them into the actual query string.
Uses implicit string conversion via an f-string for clarity.