### PR TITLE
#224 Add tests for token logging

### DIFF
--- a/src/ansys/openapi/common/_oidc.py
+++ b/src/ansys/openapi/common/_oidc.py
@@ -19,11 +19,6 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from . import SessionConfiguration
 
-if os.getenv("VERBOSE_TOKEN_DEBUGGING"):
-    _log_tokens = True
-else:
-    _log_tokens = False
-
 
 class OIDCSessionFactory:
     """
@@ -57,8 +52,13 @@ class OIDCSessionFactory:
         self._initial_session = initial_session
         self._api_url = initial_response.url
 
+        if os.getenv("VERBOSE_TOKEN_DEBUGGING"):
+            self._log_tokens = True
+        else:
+            self._log_tokens = False
+
         logger.debug("Creating OIDC session handler...")
-        if _log_tokens:
+        if self._log_tokens:
             logger.warning(
                 "Verbose token debugging is enabled. This will write sensitive information to the log. "
                 "Do not use this in production."
@@ -128,7 +128,7 @@ class OIDCSessionFactory:
         logger.info("Setting tokens...")
         if refresh_token is None:
             raise ValueError("Must provide a value for 'refresh_token', not None")
-        if _log_tokens:
+        if self._log_tokens:
             logger.debug(f"Setting refresh token: {refresh_token}")
         try:
             state, token, expires_in, new_refresh_token = self._auth.refresh_token(

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -42,7 +42,9 @@ def try_parse_and_assert_failed(response):
     return exception_info
 
 
-def get_session_from_mock_factory_with_refresh_token(refresh_token: str, log_token: bool = None):
+def get_session_from_mock_factory_with_refresh_token(
+    refresh_token: str, log_token: bool = None
+):
     mock_factory = Mock()
     mock_factory._auth = Mock()
     mock_factory._auth.refresh_token = MagicMock(
@@ -286,14 +288,18 @@ def test_endpoint_with_refresh_configures_correctly():
 
 def test_token_logging_outputs_token_to_logs(caplog):
     refresh_token = "dGhpcyBpcyBhIHRva2VuLCBob25lc3Qh"
-    session = get_session_from_mock_factory_with_refresh_token(refresh_token, log_token=True)
+    session = get_session_from_mock_factory_with_refresh_token(
+        refresh_token, log_token=True
+    )
 
     assert f"Setting refresh token: {refresh_token}" in caplog.text
 
 
 def test_disabled_token_logging(caplog):
     refresh_token = "dGhpcyBpcyBhIHRva2VuLCBob25lc3Qh"
-    session = get_session_from_mock_factory_with_refresh_token(refresh_token, log_token=False)
+    session = get_session_from_mock_factory_with_refresh_token(
+        refresh_token, log_token=False
+    )
 
     assert refresh_token not in caplog.text
 


### PR DESCRIPTION
Closes #224 

This PR adds a couple tests to ensure that the token is logged when requested to.