### PR TITLE
#281 - Output documentation for dev portal

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -144,6 +144,37 @@ jobs:
           sudo apt-get install -y texlive-latex-extra latexmk texlive-xetex fonts-freefont-otf xindy
           make -C doc latexpdf
 
+      - name: Build json documentation
+        run: |
+          # Export the documentation files to JSON files.
+          sphinx-build -M json doc/source doc-json -j auto -w build_errors.txt -N;
+
+      - name: Flatten the generated nested files into a single directory
+        run: |
+          echo Flattening a nested directory
+          mkdir doc-flatten-json;
+          echo Move all the JSON file to the flatten directory.
+          find . -name "*.fjson" -exec mv "{}" --backup=numbered ./doc-flatten-json \;
+          echo Make sure all the file has .json extensions instead of the .fjson
+          for file in doc-flatten-json/*.fjson ; do mv -- "$file" "${file%.fjson}.json" ; done;
+          echo Move all static image files to the JSON flatten folder.
+          mv doc-json/json/_images doc-flatten-json/_images;
+
+      - name: zip the flattened JSON directory
+        run: |
+          zip -r openapi-common-doc-flatten-json.zip doc-flatten-json;
+          mkdir openapi-common-doc-flatten-json;
+          mv openapi-common-doc-flatten-json.zip openapi-common-doc-flatten-json;
+          echo "Clean up build directories after the process is completed."
+          rm -rf doc-json doc-flatten-json;
+
+      - name: Upload json Documentation
+        uses: actions/upload-artifact@v3
+        with:
+          name: openapi-common-doc-flatten-json.zip
+          path: openapi-common-doc-flatten-json.zip
+          retention-days: 7
+
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -172,7 +172,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: openapi-common-doc-flatten-json.zip
-          path: openapi-common-doc-flatten-json.zip
+          path: openapi-common-doc-flatten-json
           retention-days: 7
 
       - name: Upload HTML Documentation

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Build json documentation
         run: |
           # Export the documentation files to JSON files.
-          sphinx-build -M json doc/source doc-json -j auto -w build_errors.txt -N;
+          poetry run sphinx-build -M json doc/source doc-json -j auto -w build_errors.txt -N;
 
       - name: Flatten the generated nested files into a single directory
         run: |
@@ -157,8 +157,6 @@ jobs:
           find . -name "*.fjson" -exec mv "{}" --backup=numbered ./doc-flatten-json \;
           echo Make sure all the file has .json extensions instead of the .fjson
           for file in doc-flatten-json/*.fjson ; do mv -- "$file" "${file%.fjson}.json" ; done;
-          echo Move all static image files to the JSON flatten folder.
-          mv doc-json/json/_images doc-flatten-json/_images;
 
       - name: zip the flattened JSON directory
         run: |


### PR DESCRIPTION
Closes #281 

This PR adds the documentation build and packaging steps for the dev portal. Does not currently push those changes to the appropriate branch for publishing, but stores them as a build artefact.

Based on work in https://github.com/pyansys/pyaedt/pull/1747/files