### PR TITLE
#292 - Update copyright date

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,13 +1,13 @@
 from ansys.openapi import common
 import os
 import sys
-
+from datetime import datetime
 from ansys_sphinx_theme import pyansys_logo_black
 
 # -- Project information -----------------------------------------------------
 
 project = "ansys.openapi.common"
-copyright = "(c) 2021 ANSYS, Inc. All rights reserved"
+project_copyright = f"(c) {datetime.now().year} ANSYS, Inc. All rights reserved"
 author = "ANSYS Inc."
 html_title = f"OpenAPI Common {common.__version__}"
 


### PR DESCRIPTION
Closes #292 

This PR changes the copyright date in docs to be the current year. Also changed config to use `project_copyright` instead of `copyright`