### PR TITLE
#152 Docs: add type aliases to docs

### DIFF
--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -40,3 +40,16 @@ Exceptions and Warnings
    ApiException
    ApiConnectionException
    AuthenticationWarning
+
+
+=======================
+Type aliases
+=======================
+.. currentmodule:: ansys.openapi.common._base
+
+.. autosummary::
+   :toctree: _autosummary
+
+   DeserializedType
+   SerializedType
+   PrimitiveType

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -53,7 +53,11 @@ numpydoc_xref_aliases = {
     "Dict": ":py:obj:`~typing.Dict`",
     "List": ":py:obj:`~typing.List`",
 }
-
+numpydoc_validation_exclude = {
+    "ansys.openapi.common._base.DeserializedType",
+    "ansys.openapi.common._base.SerializedType",
+    "ansys.openapi.common._base.PrimitiveType",
+}
 # Consider enabling numpydoc validation. See:
 # https://numpydoc.readthedocs.io/en/latest/validation.html#
 numpydoc_validate = True

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,10 +30,14 @@ extensions = [
     "sphinx.ext.coverage",
 ]
 
+# Sphinx
 add_module_names = False
+
+# sphinx_autodoc_typehints
 typehints_fully_qualified = True
 typehints_document_rtype = False
 
+# sphinx.ext.intersphinx
 intersphinx_mapping = {
     "python": ("https://docs.python.org/dev", None),
     "requests": ("https://requests.readthedocs.io/en/latest", None),
@@ -42,6 +46,13 @@ intersphinx_mapping = {
 # numpydoc configuration
 numpydoc_show_class_members = False
 numpydoc_xref_param_type = True
+
+numpydoc_xref_aliases = {
+    "Union": ":py:obj:`~typing.Union`",
+    "Tuple": ":py:obj:`~typing.Tuple`",
+    "Dict": ":py:obj:`~typing.Dict`",
+    "List": ":py:obj:`~typing.List`",
+}
 
 # Consider enabling numpydoc validation. See:
 # https://numpydoc.readthedocs.io/en/latest/validation.html#

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -233,7 +233,7 @@ class ApiClient(ApiClientBase):
 
         Parameters
         ----------
-        obj : DeserializedType
+        obj : :obj:`.DeserializedType`
             Data to sanitize and serialize.
 
         Examples
@@ -406,7 +406,7 @@ class ApiClient(ApiClientBase):
             Query parameters to pass in the URL.
         header_params : Union[Dict[str, Union[str, int]], List[Tuple]]
             Header parameters to place in the request header.
-        body : DeserializedType
+        body : :obj:`.DeserializedType`
             Request body.
         post_params : List[Tuple]
             Request POST form parameters for ``application/x-www-form-urlencoded`` and ``multipart/form-data``.
@@ -470,7 +470,7 @@ class ApiClient(ApiClientBase):
             Headers to attach to the request.
         post_params : List[Tuple]
             Request post form parameters for ``multipart/form-data``.
-        body : SerializedType
+        body : :obj:`.SerializedType`
             Request body.
         _preload_content : bool, optional
             Whether to return the underlying response without reading or decoding response data. The default


### PR DESCRIPTION
Closes #152 

- Add type aliases to the docs
- Add xref configuration for typing module, so that cross docs links are correctly generated in docstrings