### PR TITLE
Docs - Remove sphinx_autodoc_typehints dependency

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,7 +19,6 @@ release = version = common.__version__
 # -- General configuration ---------------------------------------------------
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx_autodoc_typehints",
     "numpydoc",
     "sphinx.ext.doctest",
     "sphinx.ext.autosummary",
@@ -33,9 +32,9 @@ extensions = [
 # Sphinx
 add_module_names = False
 
-# sphinx_autodoc_typehints
-typehints_fully_qualified = True
-typehints_document_rtype = False
+# sphinx.ext.autodoc
+autodoc_typehints = "description"
+autodoc_typehints_description_target = "documented"
 
 # sphinx.ext.intersphinx
 intersphinx_mapping = {

--- a/poetry.lock
+++ b/poetry.lock
@@ -60,7 +60,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
 
 [[package]]
 name = "babel"
@@ -116,7 +116,7 @@ optional = false
 python-versions = ">=3.5.0"
 
 [package.extras]
-unicode-backport = ["unicodedata2"]
+unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -617,7 +617,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "requests-auth"
@@ -767,22 +767,6 @@ lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-bugbear", "flake8-comprehe
 test = ["cython", "html5lib", "pytest (>=4.6)", "typed_ast"]
 
 [[package]]
-name = "sphinx-autodoc-typehints"
-version = "1.19.5"
-description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-sphinx = ">=5.3"
-
-[package.extras]
-docs = ["furo (>=2022.9.29)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.4)"]
-testing = ["covdefaults (>=2.2)", "coverage (>=6.5)", "diff-cover (>=7.0.1)", "nptyping (>=2.3.1)", "pytest (>=7.2)", "pytest-cov (>=4)", "sphobjinv (>=2.2.2)", "typing-extensions (>=4.4)"]
-type-comment = ["typed-ast (>=1.5.4)"]
-
-[[package]]
 name = "sphinx-copybutton"
 version = "0.5.1"
 description = "Add a copy button to each of your code cells."
@@ -794,7 +778,7 @@ python-versions = ">=3.7"
 sphinx = ">=1.8"
 
 [package.extras]
-code-style = ["pre-commit (==2.12.1)"]
+code_style = ["pre-commit (==2.12.1)"]
 rtd = ["ipython", "myst-nb", "sphinx", "sphinx-book-theme", "sphinx-examples"]
 
 [[package]]
@@ -962,7 +946,7 @@ oidc = ["requests_auth", "keyring"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "c01891b43e70c00fe07677040b49cdc03b47b17d2dcab64342ce7c72f7631b94"
+content-hash = "941fa4c217dfc1700f74ab6cb369182cce1295de4b20af20b8812f7b36326a0f"
 
 [metadata.files]
 alabaster = [
@@ -1439,10 +1423,6 @@ soupsieve = [
 sphinx = [
     {file = "Sphinx-5.3.0.tar.gz", hash = "sha256:51026de0a9ff9fc13c05d74913ad66047e104f56a129ff73e174eb5c3ee794b5"},
     {file = "sphinx-5.3.0-py3-none-any.whl", hash = "sha256:060ca5c9f7ba57a08a1219e547b269fadf125ae25b06b9fa7f66768efb652d6d"},
-]
-sphinx-autodoc-typehints = [
-    {file = "sphinx_autodoc_typehints-1.19.5-py3-none-any.whl", hash = "sha256:ea55b3cc3f485e3a53668bcdd08de78121ab759f9724392fdb5bf3483d786328"},
-    {file = "sphinx_autodoc_typehints-1.19.5.tar.gz", hash = "sha256:38a227378e2bc15c84e29af8cb1d7581182da1107111fd1c88b19b5eb7076205"},
 ]
 sphinx-copybutton = [
     {file = "sphinx-copybutton-0.5.1.tar.gz", hash = "sha256:366251e28a6f6041514bfb5439425210418d6c750e98d3a695b73e56866a677a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ optional = true
 ansys-sphinx-theme = { version = "0.7.1" }
 numpydoc = { version = "1.5.0" }
 sphinx = { version = "5.3.0" }
-sphinx_autodoc_typehints = { version = "1.19.5" }
 sphinx-notfound-page = { version = "0.8.3" }
 sphinx-copybutton = { version = "0.5.1" }
 


### PR DESCRIPTION
This PR removes the dependency on sphinx_autodoc_typehints. It was only used for removing typehints from signatures in the docs, which is now achieved by sphinx.ext.autodoc

I've checked the generated docs manually and the output is identical.