### PR TITLE
Review doc content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,17 @@
 # Contributing
 
-We absolutely welcome any code contributions, and we hope that this
-guide will facilitate an understanding of the openapi-common code
-repository.
+Code contributions are welcome. The objective of the documentation
+for the Open API-Common libary is to facilitate an understanding
+of the PyAnsys ``openapi-common`` repository.
 
-It is important to note that while the openapi-common
-software package is maintained by ANSYS and any submissions will be
-reviewed thoroughly before merging, we still seek to foster a community
-that can support user questions and develop new features to make this
-software a useful tool for all users.  As such, we welcome and encourage
-any questions or submissions to this repository.
+It is important to note that this Python package is maintained
+by Ansys and any submission is reviewed thoroughly before merging.
+However, we still seek to foster a community that can support
+user questions and develop new features to make this package
+useful for all users.  Thus, both questions and submissions
+to this repository are welcomed and encouraged.
 
-For more information about contributions to this project and the build
-and testing process check the contributor guide in the documentation.
-For more information about PyAnsys development guidelines and the project
-as a whole check the [PyAnsys Developer's Guide](https://github.com/pyansys/about).
+For more information about contributting to this project and the build
+and testing process, see the "Contribute" topic in the documentation.
+For information about PyAnsys development guidelines and the PyAnsys project
+as a whole, see the [PyAnsys Developer's Guide](https://github.com/pyansys/about).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-Code contributions are welcome. The objective of the documentation
-for the Open API-Common libary is to facilitate an understanding
+Code contributions are welcome. The objective of the OpenAPI-Common
+documentation is to facilitate an understanding
 of the PyAnsys ``openapi-common`` repository.
 
 It is important to note that this Python package is maintained
@@ -11,7 +11,7 @@ user questions and develop new features to make this package
 useful for all users.  Thus, both questions and submissions
 to this repository are welcomed and encouraged.
 
-For more information about contributting to this project and the build
+For more information about contributing to this project and the build
 and testing process, see the "Contribute" topic in the documentation.
 For information about PyAnsys development guidelines and the PyAnsys project
 as a whole, see the [PyAnsys Developer's Guide](https://github.com/pyansys/about).

--- a/README.rst
+++ b/README.rst
@@ -1,23 +1,25 @@
-Project Overview
-----------------
-The ``openapi-common`` repository provides the source code for authentication-aware client for OpenAPI client libraries.
+Overview
+--------
 
-The PyAnsys OpenAPI Common library is intended for use with the custom code generation
-template in the `PyAnsys project <https://github.com/pyansys>`_. This library currently
-supports authentication with Basic, Negotiate, NTLM, and OpenID Connect. Most features
-of the underlying requests session are exposed for use. Some basic configuration is also
-provided by default.
+OpenAPI-Common is intended for use with the custom code generation
+template in the `PyAnsys project <https://github.com/pyansys>`_. 
+It provides the source code for an authentication-aware
+client for OpenAPI client libraries.
 
-Installing the Source Repository
---------------------------------
+OpenAPI-Common supports authentication with Basic, Negotiate, NTLM,
+and OpenID Connect. Most features of the underlying requests session
+are exposed for use. Some basic configuration is also provided by default.
 
-Install ``openapi-common`` with:
+Installation
+------------
+
+Install the ``openapi-common`` repository with this code:
 
 .. code::
 
    pip install ansys-openapi-common
 
-Alternatively, clone and install with:
+Alternatively, clone and install the repository with this code:
 
 .. code::
 
@@ -28,8 +30,9 @@ Alternatively, clone and install with:
 
 Usage
 -----
+
 The API client class is intended to be wrapped by code that implements a client library.
-We suggest that you override the ``__init__()`` or ``connect()`` methods to add any
+You should override the ``__init__()`` or ``connect()`` method to add any
 additional behavior that might be required.
 
 Authentication is configured through the ``ApiClientFactory`` object and its ``with_xxx()``
@@ -45,26 +48,27 @@ You can provide additional configuration with the ``SessionConfiguration`` objec
    <ApiClient url: https://my-api.com/v1.svc>
 
 
-Supported Authentication Schemes
---------------------------------
-The OpenAPI Common library supports API servers configured with no authentication, API keys,
-client certificates, and basic authentication. 
+Authentication schemes
+----------------------
+
+OpenAPI-Common supports API servers configured with no authentication, API keys,
+client certificates, and basic authentication schemes. 
 
 Windows users can also use Windows Integrated Authentication to connect to Kerberos-enabled
 APIs with their Windows credentials and to NTLM where it is supported.
 
 Linux users can make use of Kerberos authentication via the ``[linux-kerberos]`` extra. This
-will require a working installation of either MIT Kerberos or Heimdal, as well as some
+requires a working installation of either MIT Kerberos or Heimdal, as well as some
 platform-specific build steps. An additional requirement is a correctly configured ``krb5.keytab``
 file on your system.
 
 Windows and Linux users can authenticate with OIDC-enabled APIs by using the ``[oidc]`` extra.
-Currently we support only the Authorization Code authentication flow.
+Currently only the Authorization Code authentication flow is supported.
 
-.. list-table:: Authentication Methods by Platform
+.. list-table:: Authentication methods by platform
    :header-rows: 1
 
-   * - Authentication Method
+   * - Authentication method
      - Windows
      - Linux
      - Builder method
@@ -100,18 +104,18 @@ Currently we support only the Authorization Code authentication flow.
      - ``.with_oidc()``
      -
 
-Platform-specific Kerberos Configuration
+Platform-specific Kerberos configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Kerberos authentication should be supported wherever the MIT or Heimdal Kerberos client
-can be installed. The OpenAPI Common library has been tested on the platforms listed below.
+can be installed. OpenAPI-Common has been tested on the platforms that follow.
 If you manage to use it on another platform, consider contributing installation steps for
 your platform by making a pull request.
 
 Ubuntu 20.04
 ============
 
-Ubuntu requires the Python module ``gssapi`` to be built from source. This requires the
+Ubuntu requires the ``gssapi`` Python module to be built from source. This requires the
 Kerberos headers, Python headers for the version of Python that you are using, and a
 supported compiler. (GCC works well.)
 
@@ -122,11 +126,12 @@ You should then be able to install this module with the ``[linux-kerberos]`` ext
    sudo apt install build-essentials python3.8-dev libkrb5-dev
    pip install ansys-openapi-common[linux-kerberos]
 
+
 Once the installation completes, ensure that your ``krb5.conf`` file is set up correctly
-for your Kerberos configuration and that you have a valid ``keytab file``, which is
+for your Kerberos configuration and that you have a valid ``keytab`` file, which is
 normally in ``/etc/krb5.keytab``.
 
 License
 -------
-The OpenAPI Common library is provided under the terms of the MIT license. You can find
+OpenAPI-Common is provided under the terms of the MIT license. You can find
 the license text in the LICENSE file at the root of the repository.

--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -1,0 +1,28 @@
+# Core settings
+# =============
+
+# Location of our `styles`
+StylesPath = "styles"
+
+# The options are `suggestion`, `warning`, or `error` (defaults to “warning”).
+MinAlertLevel = warning
+
+# By default, `code` and `tt` are ignored.
+IgnoredScopes = code, tt
+
+# By default, `script`, `style`, `pre`, and `figure` are ignored.
+SkippedScopes = script, style, pre, figure
+
+# WordTemplate specifies what Vale will consider to be an individual word.
+WordTemplate = \b(?:%s)\b
+
+# List of Packages to be used for our guidelines
+Packages = Google
+
+# Define the Ansys vocabulary
+Vocab = ANSYS
+
+[*.{md,rst}]
+
+# Apply the following styles
+BasedOnStyles = Vale, Google

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -1,14 +1,14 @@
 .. _ref_index_api:
 
 =============
-API Reference
+API reference
 =============
 
 .. currentmodule:: ansys.openapi.common
 
 
-This section summarizes the ``openapi-common`` public
-classes, functions, and attributes.
+This section summarizes OpenAPI-Common public
+classes.
 
 .. autosummary::
    :toctree: _autosummary
@@ -20,8 +20,10 @@ classes, functions, and attributes.
 
 
 ================
-Helper Functions
+Helper functions
 ================
+
+This section summarizes OpenAPI-Common helper functions.
 
 .. autosummary::
    :toctree: _autosummary
@@ -31,8 +33,10 @@ Helper Functions
 
 
 =======================
-Exceptions and Warnings
+Exceptions and warnings
 =======================
+
+This section summarizes OpenAPI-Common attributes.
 
 .. autosummary::
    :toctree: _autosummary
@@ -42,9 +46,9 @@ Exceptions and Warnings
    AuthenticationWarning
 
 
-=======================
+============
 Type aliases
-=======================
+============
 .. currentmodule:: ansys.openapi.common._base
 
 .. autosummary::

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -1,22 +1,21 @@
 .. _contributing_openapi:
 
-============
-Contributing
-============
+==========
+Contribute
+==========
 Overall guidance on contributing to a PyAnsys library appears in the
 `Contributing <https://dev.docs.pyansys.com/overview/contributing.html>`_ topic
 in the *PyAnsys Developer's Guide*. Ensure that you are thoroughly familiar
-with it and all `Guidelines and Best Practices <https://dev.docs.pyansys.com/guidelines/index.html>`_
-before attempting to contribute to the OpenAPI Common library.
+with this guide before attempting to contribute to OpenAPI-Common.
  
-The following contribution information is specific to the OpenAPI Common library.
+The following contribution information is specific to OpenAPI-Common.
 
 
-Cloning the Source Repository
------------------------------
+Clone the repository
+--------------------
 
-Run this code to clone and install the latest version of the ``openapi-common``
-repository:
+To clone and install the latest version of OpenAPI-Common in *development* mode,
+run:
 
 .. code::
 
@@ -25,15 +24,15 @@ repository:
     pip install .
 
 
-Posting Issues
---------------
-Use the `OpenAPI Common Issues <https://github.com/pyansys/openapi-common/issues>`_ page
+Post issues
+-----------
+Use the `OpenAPI-Common Issues <https://github.com/pyansys/openapi-common/issues>`_ page
 to submit questions, report bugs, and request new features.
 
 To reach the support team, email `pyansys.support@ansys.com <pyansys.support@ansys.com>`_.
 
-Viewing OpenAPI Common Documentation
-------------------------------------
-Documentation for the latest stable release of the OpenAPI Common library
-is hosted at `OpenAPI Common Documentation <https://openapi.docs.pyansys.com>`_.  
+View OpenAPI-Common documentation
+---------------------------------
+Documentation for the latest stable release of OpenAPI-Common
+is hosted at `OpenAPI-Common Documentation <https://openapi.docs.pyansys.com>`_.  
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,4 +1,4 @@
-OpenAPI Common |version|
+OpenAPI-Common |version|
 ========================
 
 .. toctree::
@@ -9,25 +9,24 @@ OpenAPI Common |version|
    contributing
 
 
-Introduction and Purpose
-------------------------
-The OpenAPI Common library is part of the larger PyAnsys effort to
-facilitate the use of Ansys technologies directly from within Python.
+Introduction
+------------
+OpenAPI-Common is part of the larger `PyAnsys <https://docs.pyansys.com>`_
+effort to facilitate the use of Ansys technologies directly from Python.
 
 Because some Ansys products expose HTTP APIs rather than gRPC
-APIs, this library provides a common client to consume
+APIs, this Python library provides a common client to consume
 HTTP APIs, minimizing overhead and reducing code duplication.
 
 
 Background
 ----------
 A widely used standard for HTTP REST-style APIs is the OpenAPI standard,
-formerly known as Swagger. The OpenAPI Common library is designed to be
-used alongside code generation tools to produce client libraries for HTTP
-APIs.
+formerly known as Swagger. OpenAPI-Common is designed to be used alongside
+code generation tools to produce client libraries for HTTP APIs.
 
 
-Brief Example
+Brief example
 -------------
 This brief example demonstrates how the client works:
 
@@ -41,29 +40,30 @@ This brief example demonstrates how the client works:
 
     <ApiClient url: http://my-api.com>
 
+
 The client is now ready and available for use with an OpenAPI client.
 
-Supported Authentication Schemes
---------------------------------
-The OpenAPI Common library supports API servers configured with no authentication, API keys,
+Authentication schemes
+----------------------
+OpenAPI-Common supports API servers configured with no authentication, API keys,
 client certificates, and basic authentication. 
 
 Windows users can also use Windows Integrated Authentication to connect to Kerberos-enabled
 APIs with their Windows credentials and to NTLM where it is supported.
 
 Linux users can make use of Kerberos authentication via the ``[linux-kerberos]`` extra. This
-will require a working installation of either MIT Kerberos or Heimdal, as well as some
+requires a working installation of either MIT Kerberos or Heimdal, as well as some
 platform-specific build steps. An additional requirement is a correctly configured ``krb5.keytab``
 file on your system.
 
 Windows and Linux users can authenticate with OIDC-enabled APIs by using the ``[oidc]`` extra.
-Currently we support only the Authorization Code authentication flow.
+Currently only the Authorization Code authentication flow is supported.
 
-.. list-table:: Authentication Methods by Platform
+.. list-table:: Authentication methods by platform
    :header-rows: 1
    :widths: 30 15 15 40
 
-   * - Authentication Method
+   * - Authentication method
      - Windows
      - Linux
      - Builder method
@@ -92,7 +92,7 @@ Currently we support only the Authorization Code authentication flow.
 .. [2] When installed as ``pip install ansys-openapi-common[linux-kerberos]``.
 .. [3] When installed as ``pip install ansys-openapi-common[oidc]``.
 
-Advanced Features
+Advanced features
 -----------------
 You can set all options that are available in Python library *requests* through
 the client. This enables you to configure custom SSL certificate validation, send
@@ -109,18 +109,19 @@ For example, to send a client certificate with every request:
    ... )
    >>> client.configuration = configuration
 
-Platform-specific Kerberos Configuration
+
+Platform-specific Kerberos configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Kerberos authentication should be supported wherever the MIT or Heimdal Kerberos client
-can be installed. The OpenAPI Common library has been tested on the platforms listed below.
+can be installed. OpenAPI-Common has been tested on the platforms that follow.
 If you manage to use it on another platform, consider contributing installation steps for
 your platform by making a pull request.
 
 Ubuntu 20.04
 ^^^^^^^^^^^^
 
-Ubuntu requires the Python module ``gssapi`` to be built from source. This requires the
+Ubuntu requires the ``gssapi`` Python module to be built from source. This requires the
 Kerberos headers, Python headers for the version of Python that you are using, and a
 supported compiler. (GCC works well.)
 
@@ -131,20 +132,21 @@ You should then be able to install this module with the ``[linux-kerberos]`` ext
    sudo apt install build-essentials python3.8-dev libkrb5-dev
    pip install ansys-openapi-common[linux-kerberos]
 
+
 Once the installation completes, ensure that your ``krb5.conf`` file is set up correctly
-for your Kerberos configuration and that you have a valid ``keytab file``, which is
+for your Kerberos configuration and that you have a valid ``keytab`` file, which is
 normally in ``/etc/krb5.keytab``.
 
-API Reference
+API reference
 -------------
 For comprehensive API documentation, see :doc:`API reference <api/index>`.
 
-Contributing
-------------
-We welcome contributions to this library. For more information, see
-:doc:`Contributing<contributing>`.
+Contributions
+-------------
+Contributions to this library are welcome. For more information, see
+:ref: `_contributing_openapi`.
 
-Project Index
+Project index
 -------------
 
 * :ref:`genindex`

--- a/doc/styles/.gitignore
+++ b/doc/styles/.gitignore
@@ -1,0 +1,4 @@
+*
+!Vocab
+!Vocab/**
+!.gitignore

--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -1,0 +1,5 @@
+ANSYS
+Ansys
+ansys
+OpenAPI
+OpenAPI-Common

--- a/src/ansys/openapi/common/_util.py
+++ b/src/ansys/openapi/common/_util.py
@@ -365,7 +365,7 @@ def handle_response(response: requests.Response) -> requests.Response:
 
 
 def generate_user_agent(package_name: str, package_version: str) -> str:
-    """Generate a user-agent string in the form <package info> <python info> <os info>.
+    """Generate a user-agent string in the form ``*<package info>*`` ``*<python info>*`` ``*<os info>*``.
 
     Parameters
     ----------

--- a/src/ansys/openapi/common/_util.py
+++ b/src/ansys/openapi/common/_util.py
@@ -365,7 +365,7 @@ def handle_response(response: requests.Response) -> requests.Response:
 
 
 def generate_user_agent(package_name: str, package_version: str) -> str:
-    """Generate a user-agent string in the form *``<package info> <python info> <os info>``*.
+    """Generate a user-agent string in the form *<package info> <python info> <os info>*.
 
     Parameters
     ----------

--- a/src/ansys/openapi/common/_util.py
+++ b/src/ansys/openapi/common/_util.py
@@ -365,7 +365,7 @@ def handle_response(response: requests.Response) -> requests.Response:
 
 
 def generate_user_agent(package_name: str, package_version: str) -> str:
-    """Generate a user-agent string in the form ``*<package info>*`` ``*<python info>*`` ``*<os info>*``.
+    """Generate a user-agent string in the form *``<package info> <python info> <os info>``*.
 
     Parameters
     ----------


### PR DESCRIPTION
@Andy-Grigg I've performed an overall doc review. However, I don't know where the "shared components" text comes from. I've used the convention OpenAPI-Common as the library name to match the convention for other PyAnsys libraries. I will need to do this in the Shared Components content. There also seems to be a good bit of redundant but unused information in the small number of files for this repository.

Lastly, I copied in Vale folders/files, but Vale will still need to be implemented as part of the CI/CD process. I thought having the folders/files there would save you a step or two.