### PR TITLE
Add response type mapping for response deserializing

### DIFF
--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -119,7 +119,7 @@ class ApiClient(ApiClientBase):
         body: Optional[Any] = None,
         post_params: Optional[Any] = None,
         files: Optional[Any] = None,
-        response_type: Optional[str] = None,
+        response_type: Union[str, Dict[int, str], None] = None,
         _return_http_data_only: Optional[bool] = None,
         collection_formats: Optional[Dict[str, str]] = None,
         _preload_content: bool = True,
@@ -178,6 +178,8 @@ class ApiClient(ApiClientBase):
 
         return_data: Union[requests.Response, DeserializedType, None] = response_data
         if _preload_content:
+            if isinstance(response_type, dict):
+                response_type = response_type.get(return_data.status_code, None)
             # deserialize response data
             if response_type:
                 return_data = self.deserialize(response_data, response_type)
@@ -386,7 +388,7 @@ class ApiClient(ApiClientBase):
         body: Optional[DeserializedType] = None,
         post_params: Optional[List[Tuple]] = None,
         files: Optional[Dict[str, str]] = None,
-        response_type: Optional[str] = None,
+        response_type: Union[str, Dict[int, str], None] = None,
         _return_http_data_only: Optional[bool] = None,
         collection_formats: Optional[Dict[str, str]] = None,
         _preload_content: bool = True,
@@ -410,8 +412,8 @@ class ApiClient(ApiClientBase):
             Request body.
         post_params : List[Tuple]
             Request POST form parameters for ``application/x-www-form-urlencoded`` and ``multipart/form-data``.
-        response_type : str, optional
-            Expected response data type.
+        response_type : Union[str, Dict[int, str]], optional
+            Expected response data type or mapping between response status code and associated response data type.
         files : Dict[str, str]
             Dictionary of the file name and path for ``multipart/form-data``.
         _return_http_data_only : bool, optional

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -124,7 +124,7 @@ class ApiClient(ApiClientBase):
         collection_formats: Optional[Dict[str, str]] = None,
         _preload_content: bool = True,
         _request_timeout: Optional[Union[float, Tuple[float]]] = None,
-        response_type_map: Optional[Dict[int, str]] = None,
+        response_type_map: Optional[Dict[int, Union[str, None]]] = None,
     ) -> Union[requests.Response, DeserializedType, None]:
         # header parameters
         header_params = header_params or {}
@@ -394,7 +394,7 @@ class ApiClient(ApiClientBase):
         collection_formats: Optional[Dict[str, str]] = None,
         _preload_content: bool = True,
         _request_timeout: Union[float, Tuple[float], None] = None,
-        response_type_map: Optional[Dict[int, str]] = None,
+        response_type_map: Optional[Dict[int, Union[str, None]]] = None,
     ) -> Union[requests.Response, DeserializedType, None]:
         """Make the HTTP request and return the deserialized data.
 
@@ -432,7 +432,7 @@ class ApiClient(ApiClientBase):
             Timeout setting for the request. If only one number is provided, it is used as a total request timeout.
             It can also be a pair (tuple) of (connection, read) timeouts. This parameter overrides the session-level
             timeout setting.
-        response_type_map : Dict[int, str]
+        response_type_map : Dict[int, Union[str, None]]
             Dictionary of response status codes and response types for response deserialization. If provided, has
             precedence over response_type.
         """

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -178,16 +178,11 @@ class ApiClient(ApiClientBase):
 
         return_data: Union[requests.Response, DeserializedType, None] = response_data
         if _preload_content:
-            _response_type: Optional[str]
+            _response_type = response_type
             if response_type_map is not None:
                 _response_type = response_type_map.get(response_data.status_code, None)
-            else:
-                _response_type = response_type
-            # deserialize response data
-            if _response_type:
-                return_data = self.deserialize(response_data, _response_type)
-            else:
-                return_data = None
+
+            return_data = self.deserialize(response_data, _response_type)
 
         if _return_http_data_only:
             return return_data
@@ -280,7 +275,7 @@ class ApiClient(ApiClientBase):
         }
 
     def deserialize(
-        self, response: requests.Response, response_type: str
+        self, response: requests.Response, response_type: Optional[str]
     ) -> DeserializedType:
         """Deserialize the response into an object.
 
@@ -320,6 +315,9 @@ class ApiClient(ApiClientBase):
         ... client.deserialize(api_response, 'datetime.datetime')
         datetime.datetime(2015, 10, 21, 10, 5, 10)
         """
+
+        if response_type is None:
+            return None
 
         if response_type == "file":
             return self.__deserialize_file(response)

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -126,7 +126,6 @@ class ApiClient(ApiClientBase):
         _request_timeout: Optional[Union[float, Tuple[float]]] = None,
         response_type_map: Optional[Dict[int, str]] = None,
     ) -> Union[requests.Response, DeserializedType, None]:
-
         # header parameters
         header_params = header_params or {}
         if header_params:

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -119,11 +119,12 @@ class ApiClient(ApiClientBase):
         body: Optional[Any] = None,
         post_params: Optional[Any] = None,
         files: Optional[Any] = None,
-        response_type: Union[str, Dict[int, str], None] = None,
+        response_type: Optional[str] = None,
         _return_http_data_only: Optional[bool] = None,
         collection_formats: Optional[Dict[str, str]] = None,
         _preload_content: bool = True,
         _request_timeout: Optional[Union[float, Tuple[float]]] = None,
+        response_type_map: Optional[Dict[int, str]] = None,
     ) -> Union[requests.Response, DeserializedType, None]:
 
         # header parameters
@@ -179,8 +180,8 @@ class ApiClient(ApiClientBase):
         return_data: Union[requests.Response, DeserializedType, None] = response_data
         if _preload_content:
             _response_type: Optional[str]
-            if isinstance(response_type, dict):
-                _response_type = response_type.get(response_data.status_code, None)
+            if response_type_map is not None:
+                _response_type = response_type_map.get(response_data.status_code, None)
             else:
                 _response_type = response_type
             # deserialize response data
@@ -391,11 +392,12 @@ class ApiClient(ApiClientBase):
         body: Optional[DeserializedType] = None,
         post_params: Optional[List[Tuple]] = None,
         files: Optional[Dict[str, str]] = None,
-        response_type: Union[str, Dict[int, str], None] = None,
+        response_type: Optional[str] = None,
         _return_http_data_only: Optional[bool] = None,
         collection_formats: Optional[Dict[str, str]] = None,
         _preload_content: bool = True,
         _request_timeout: Union[float, Tuple[float], None] = None,
+        response_type_map: Optional[Dict[int, str]] = None,
     ) -> Union[requests.Response, DeserializedType, None]:
         """Make the HTTP request and return the deserialized data.
 
@@ -415,8 +417,8 @@ class ApiClient(ApiClientBase):
             Request body.
         post_params : List[Tuple]
             Request POST form parameters for ``application/x-www-form-urlencoded`` and ``multipart/form-data``.
-        response_type : Union[str, Dict[int, str]], optional
-            Expected response data type or mapping between response status code and associated response data type.
+        response_type : str, optional
+            Expected response data type.
         files : Dict[str, str]
             Dictionary of the file name and path for ``multipart/form-data``.
         _return_http_data_only : bool, optional
@@ -433,6 +435,9 @@ class ApiClient(ApiClientBase):
             Timeout setting for the request. If only one number is provided, it is used as a total request timeout.
             It can also be a pair (tuple) of (connection, read) timeouts. This parameter overrides the session-level
             timeout setting.
+        response_type_map : Dict[int, str]
+            Dictionary of response status codes and response types for response deserialization. If provided, has
+            precedence over response_type.
         """
         return self.__call_api(
             resource_path,
@@ -448,6 +453,7 @@ class ApiClient(ApiClientBase):
             collection_formats,
             _preload_content,
             _request_timeout,
+            response_type_map,
         )
 
     def request(

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -178,11 +178,14 @@ class ApiClient(ApiClientBase):
 
         return_data: Union[requests.Response, DeserializedType, None] = response_data
         if _preload_content:
+            _response_type: Optional[str]
             if isinstance(response_type, dict):
-                response_type = response_type.get(return_data.status_code, None)
+                _response_type = response_type.get(response_data.status_code, None)
+            else:
+                _response_type = response_type
             # deserialize response data
-            if response_type:
-                return_data = self.deserialize(response_data, response_type)
+            if _response_type:
+                return_data = self.deserialize(response_data, _response_type)
             else:
                 return_data = None
 

--- a/src/ansys/openapi/common/_base/_types.py
+++ b/src/ansys/openapi/common/_base/_types.py
@@ -79,6 +79,6 @@ class ApiClientBase(metaclass=abc.ABCMeta):
         collection_formats: Optional[Dict[str, str]] = None,
         _preload_content: bool = True,
         _request_timeout: Union[float, Tuple[float], None] = None,
-        response_type_map: Optional[Dict[int, str]] = None,
+        response_type_map: Optional[Dict[int, Union[str, None]]] = None,
     ) -> Union[requests.Response, DeserializedType, None]:
         ...

--- a/src/ansys/openapi/common/_base/_types.py
+++ b/src/ansys/openapi/common/_base/_types.py
@@ -79,5 +79,6 @@ class ApiClientBase(metaclass=abc.ABCMeta):
         collection_formats: Optional[Dict[str, str]] = None,
         _preload_content: bool = True,
         _request_timeout: Union[float, Tuple[float], None] = None,
+        response_type_map: Optional[Dict[int, str]] = None,
     ) -> Union[requests.Response, DeserializedType, None]:
         ...

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -842,15 +842,16 @@ class TestMultipleResponseTypesHandling:
         self._model = example_model
 
     _serialized_data = {
-            "String": "new_model",
-            "Integer": 1,
-            "ListOfStrings": ["red", "green"],
-            "Boolean": False,
-        }
+        "String": "new_model",
+        "Integer": 1,
+        "ListOfStrings": ["red", "green"],
+        "Boolean": False,
+    }
 
     @property
     def _deserialized_data(self):
         from tests.models import ExampleModel
+
         return ExampleModel(
             string_property="new_model",
             int_property=1,
@@ -859,12 +860,18 @@ class TestMultipleResponseTypesHandling:
         )
 
     _configured_response_types = {
-            200: "ExampleModel",
-            201: "str",
-            202: None,
-        }
+        200: "ExampleModel",
+        201: "str",
+        202: None,
+    }
 
-    def _mock_response_and_process(self, response_code: int, response_json=None, response_text=None, response_types=None):
+    def _mock_response_and_process(
+        self,
+        response_code: int,
+        response_json=None,
+        response_text=None,
+        response_types=None,
+    ):
         resource_path = "/models"
         method = "POST"
 
@@ -887,19 +894,28 @@ class TestMultipleResponseTypesHandling:
                 text=response_text,
             )
             response, status_code, headers = self._client.call_api(
-                resource_path, method, body=upload_data,
-                response_type=self._configured_response_types if response_types is None else response_types
+                resource_path,
+                method,
+                body=upload_data,
+                response_type=self._configured_response_types
+                if response_types is None
+                else response_types,
             )
         return response, status_code, headers
 
     def test_expected_model_deserialized_from_json(self):
-        response, status_code, headers = self._mock_response_and_process(200, self._serialized_data)
+        response, status_code, headers = self._mock_response_and_process(
+            200, self._serialized_data
+        )
         from tests.models import ExampleModel
+
         assert isinstance(response, ExampleModel)
         assert response == self._deserialized_data
 
     def test_response_type_configured_and_text_response(self):
-        response, status_code, headers = self._mock_response_and_process(201, response_text="some_id")
+        response, status_code, headers = self._mock_response_and_process(
+            201, response_text="some_id"
+        )
         assert response == "some_id"
 
     def test_no_response_type_configured_and_empty_response(self):
@@ -907,19 +923,27 @@ class TestMultipleResponseTypesHandling:
         assert response is None
 
     def test_no_response_type_configured_and_json_response(self):
-        response, status_code, headers = self._mock_response_and_process(202, self._serialized_data)
+        response, status_code, headers = self._mock_response_and_process(
+            202, self._serialized_data
+        )
         assert response is None
 
     def test_no_response_type_configured_with_json_in_response(self):
-        response, status_code, headers = self._mock_response_and_process(200, self._serialized_data, response_types={})
+        response, status_code, headers = self._mock_response_and_process(
+            200, self._serialized_data, response_types={}
+        )
         assert response is None
 
     def test_no_response_type_configured_with_text_in_response(self):
-        response, status_code, headers = self._mock_response_and_process(200, response_text="Some text", response_types={})
+        response, status_code, headers = self._mock_response_and_process(
+            200, response_text="Some text", response_types={}
+        )
         assert response is None
 
     def test_no_response_type_configured_with_empty_response(self):
-        response, status_code, headers = self._mock_response_and_process(200, response_types={})
+        response, status_code, headers = self._mock_response_and_process(
+            200, response_types={}
+        )
         assert response is None
 
 

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -402,6 +402,14 @@ class TestResponseParsing:
         response.connection = self._connection
         return response
 
+    def test_response_is_not_deserialized_if_type_is_none(self, mocker):
+        data = {"one": 1, "two": 2, "three": 3}
+        response = self.create_response(data)
+        _deserialize_mock = mocker.patch.object(ApiClient, "_ApiClient__deserialize")
+        result = self._client.deserialize(response, None)
+        assert result is None
+        _deserialize_mock.assert_not_called()
+
     def test_json_parsed_as_json(self, mocker):
         data = {"one": 1, "two": 2, "three": 3}
         response = self.create_response(data)
@@ -894,12 +902,10 @@ class TestMultipleResponseTypesHandling:
                 response_type=response_type,
                 response_type_map=response_type_map,
             )
-        if expected_type is not None:
-            deserialize_mock.assert_called_once()
-            last_call_pos_args = deserialize_mock.call_args[0]
-            assert last_call_pos_args[1] == expected_type
-        else:
-            assert deserialize_mock.called is False
+
+        deserialize_mock.assert_called_once()
+        last_call_pos_args = deserialize_mock.call_args[0]
+        assert last_call_pos_args[1] == expected_type
 
 
 class TestStaticMethods:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -674,7 +674,8 @@ class TestResponseHandling:
 
     def test_patch_object(self):
         """This test represents updating a value on an existing record using a custom json payload. The new object
-        is returned. This questionable API accepts an ID as a query param and returns the updated object"""
+        is returned. This questionable API accepts an ID as a query param and returns the updated object
+        """
 
         expected_request = {
             "ListOfStrings": ["red", "yellow", "green"],
@@ -894,8 +895,9 @@ class TestMultipleResponseTypesHandling:
                 response_type_map=response_type_map,
             )
         if expected_type is not None:
-            assert deserialize_mock.call_count == 1
-            assert deserialize_mock.mock_calls[0].args[1] == expected_type
+            deserialize_mock.assert_called_once()
+            last_call_pos_args = deserialize_mock.call_args[0]
+            assert last_call_pos_args[1] == expected_type
         else:
             assert deserialize_mock.called is False
 
@@ -1025,7 +1027,8 @@ class TestStaticMethods:
     ):
         """This test needs a little explanation. The prepare_post_parameters method is odd, it returns the result
         in a return statement but also mutates the input argument. I suspect this is not intentional, but for the moment
-        the test works around this by copying the initial state of the parameter list."""
+        the test works around this by copying the initial state of the parameter list.
+        """
         # TODO - Can we remove this weirdness?
         if text_parameters is None:
             initial_text_parameters = []


### PR DESCRIPTION
Closes #311 

This PR adds a new parameter to `call_api`, so that auto-generated API method code can specify different response types for each response status codes