### PR TITLE
Include more details in the ApiConnectionException message

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -335,6 +335,8 @@ files = [
     {file = "cryptography-39.0.1-cp36-abi3-win32.whl", hash = "sha256:fe913f20024eb2cb2f323e42a64bdf2911bb9738a15dba7d3cce48151034e3a8"},
     {file = "cryptography-39.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:ced4e447ae29ca194449a3f1ce132ded8fcab06971ef5f618605aacaa612beac"},
     {file = "cryptography-39.0.1-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:807ce09d4434881ca3a7594733669bd834f5b2c6d5c7e36f8c00f691887042ad"},
+    {file = "cryptography-39.0.1-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c5caeb8188c24888c90b5108a441c106f7faa4c4c075a2bcae438c6e8ca73cef"},
+    {file = "cryptography-39.0.1-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:4789d1e3e257965e960232345002262ede4d094d1a19f4d3b52e48d4d8f3b885"},
     {file = "cryptography-39.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:96f1157a7c08b5b189b16b47bc9db2332269d6680a196341bf30046330d15388"},
     {file = "cryptography-39.0.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e422abdec8b5fa8462aa016786680720d78bdce7a30c652b7fadf83a4ba35336"},
     {file = "cryptography-39.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:b0afd054cd42f3d213bf82c629efb1ee5f22eba35bf0eec88ea9ea7304f511a2"},
@@ -399,19 +401,19 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.89.1"
+version = "0.91.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "fastapi-0.89.1-py3-none-any.whl", hash = "sha256:f9773ea22290635b2f48b4275b2bf69a8fa721fda2e38228bed47139839dc877"},
-    {file = "fastapi-0.89.1.tar.gz", hash = "sha256:15d9271ee52b572a015ca2ae5c72e1ce4241dd8532a534ad4f7ec70c376a580f"},
+    {file = "fastapi-0.91.0-py3-none-any.whl", hash = "sha256:8dc18f860755159b3c4b30577c61c821b98f382acfeb6d5a849f9fa6a5369789"},
+    {file = "fastapi-0.91.0.tar.gz", hash = "sha256:ff2fa93af3f2f982b07b5f96e8512565b3ef0e5f8f02469dbfd6bc27f6fd9a9e"},
 ]
 
 [package.dependencies]
 pydantic = ">=1.6.2,<1.7 || >1.7,<1.7.1 || >1.7.1,<1.7.2 || >1.7.2,<1.7.3 || >1.7.3,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0"
-starlette = "0.22.0"
+starlette = ">=0.24.0,<0.25.0"
 
 [package.extras]
 all = ["email-validator (>=1.1.1)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=2.11.2)", "orjson (>=3.2.1)", "python-multipart (>=0.0.5)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
@@ -1402,14 +1404,14 @@ test = ["pytest"]
 
 [[package]]
 name = "starlette"
-version = "0.22.0"
+version = "0.24.0"
 description = "The little ASGI library that shines."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "starlette-0.22.0-py3-none-any.whl", hash = "sha256:b5eda991ad5f0ee5d8ce4c4540202a573bb6691ecd0c712262d0bc85cf8f2c50"},
-    {file = "starlette-0.22.0.tar.gz", hash = "sha256:b092cbc365bea34dd6840b42861bdabb2f507f8671e642e8272d2442e08ea4ff"},
+    {file = "starlette-0.24.0-py3-none-any.whl", hash = "sha256:75e2b24d71ff4f7cb9a3338f83d234c2d4135bf80f52aeb105c02a01d72a5df1"},
+    {file = "starlette-0.24.0.tar.gz", hash = "sha256:7925947f177a19e906c6ace10f07c64c4f9fdf7d509caaac6589f7cc0cfd95f3"},
 ]
 
 [package.dependencies]

--- a/src/ansys/openapi/common/_exceptions.py
+++ b/src/ansys/openapi/common/_exceptions.py
@@ -19,9 +19,7 @@ class ApiConnectionException(Exception):
     """
 
     def __init__(self, response: "requests.Response"):
-        exception_message = (
-            f"Request url '{response.url}' failed with reason {response.status_code}: {response.reason}."
-        )
+        exception_message = f"Request url '{response.url}' failed with reason {response.status_code}: {response.reason}."
         if response.text:
             exception_message += f"\n{response.text}"
         super().__init__(exception_message)

--- a/src/ansys/openapi/common/_exceptions.py
+++ b/src/ansys/openapi/common/_exceptions.py
@@ -26,10 +26,10 @@ class ApiConnectionException(Exception):
 
     def __init__(self, url: str, status_code: int, reason_phrase: str, content: str):
         message = (
-            f"Request url '{url}' failed with reason {status_code}: {reason_phrase}.\n"
-            f"The following was returned by the server:\n"
-            f"{content}"
+            f"Request url '{url}' failed with reason {status_code}: {reason_phrase}."
         )
+        if content:
+            message += f"\nThe following was returned by the server:\n{content}"
         super().__init__(message)
         self.url = url
         self.status_code = status_code

--- a/src/ansys/openapi/common/_exceptions.py
+++ b/src/ansys/openapi/common/_exceptions.py
@@ -14,30 +14,32 @@ class ApiConnectionException(Exception):
 
     Attributes
     ----------
-    url : str
-        The URL for which the request failed.
     status_code : int
         HTTP status code associated with the response.
     reason_phrase : str
         Description of the response provided by the server.
-    content : str
+    message : str
         Content of the response provided by the server.
+    url : str
+        The URL for which the request failed.
     """
 
-    def __init__(self, url: str, status_code: int, reason_phrase: str, content: str):
-        message = (
+    def __init__(self, status_code: int, reason_phrase: str, message: str, url: str):
+        exception_message = (
             f"Request url '{url}' failed with reason {status_code}: {reason_phrase}."
         )
-        if content:
-            message += f"\nThe following was returned by the server:\n{content}"
-        super().__init__(message)
-        self.url = url
+        if message:
+            exception_message += (
+                f"\nThe following was returned by the server:\n{message}"
+            )
+        super().__init__(exception_message)
         self.status_code = status_code
         self.reason_phrase = reason_phrase
-        self.content = content
+        self.message = message
+        self.url = url
 
     def __repr__(self) -> str:
-        return f"ApiConnectionException('{self.url}', {self.status_code}, '{self.reason_phrase}','{self.content}')"
+        return f"ApiConnectionException({self.status_code}, '{self.reason_phrase}', '{self.message}', '{self.url}')"
 
 
 class AuthenticationWarning(Warning):

--- a/src/ansys/openapi/common/_exceptions.py
+++ b/src/ansys/openapi/common/_exceptions.py
@@ -14,23 +14,30 @@ class ApiConnectionException(Exception):
 
     Attributes
     ----------
+    url : str
+        The URL for which the request failed.
     status_code : int
         HTTP status code associated with the response.
     reason_phrase : str
         Description of the response provided by the server.
-    message : str
+    content : str
         Content of the response provided by the server.
-
     """
 
-    def __init__(self, status_code: int, reason_phrase: str, message: str):
+    def __init__(self, url: str, status_code: int, reason_phrase: str, content: str):
+        message = (
+            f"Request url '{url}' failed with reason {status_code}: {reason_phrase}.\n"
+            f"The following was returned by the server:\n"
+            f"{content}"
+        )
+        super().__init__(message)
+        self.url = url
         self.status_code = status_code
         self.reason_phrase = reason_phrase
-        self.message = message
-        super().__init__(message)
+        self.content = content
 
     def __repr__(self) -> str:
-        return f"ApiConnectionException({self.status_code}, '{self.reason_phrase}','{self.message}')"
+        return f"ApiConnectionException('{self.url}', {self.status_code}, '{self.reason_phrase}','{self.content}')"
 
 
 class AuthenticationWarning(Warning):

--- a/src/ansys/openapi/common/_exceptions.py
+++ b/src/ansys/openapi/common/_exceptions.py
@@ -14,32 +14,21 @@ class ApiConnectionException(Exception):
 
     Attributes
     ----------
-    status_code : int
-        HTTP status code associated with the response.
-    reason_phrase : str
-        Description of the response provided by the server.
-    message : str
-        Content of the response provided by the server.
-    url : str
-        The URL for which the request failed.
+    response : requests.Response
+        Response from the server.
     """
 
-    def __init__(self, status_code: int, reason_phrase: str, message: str, url: str):
+    def __init__(self, response: "requests.Response"):
         exception_message = (
-            f"Request url '{url}' failed with reason {status_code}: {reason_phrase}."
+            f"Request url '{response.url}' failed with reason {response.status_code}: {response.reason}."
         )
-        if message:
-            exception_message += (
-                f"\nThe following was returned by the server:\n{message}"
-            )
+        if response.text:
+            exception_message += f"\n{response.text}"
         super().__init__(exception_message)
-        self.status_code = status_code
-        self.reason_phrase = reason_phrase
-        self.message = message
-        self.url = url
+        self.response = response
 
     def __repr__(self) -> str:
-        return f"ApiConnectionException({self.status_code}, '{self.reason_phrase}', '{self.message}', '{self.url}')"
+        return f"ApiConnectionException({repr(self.response)})"
 
 
 class AuthenticationWarning(Warning):

--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -314,7 +314,9 @@ class ApiClientFactory:
         if 200 <= resp.status_code < 300:
             return True
         else:
-            raise ApiConnectionException(resp.status_code, resp.reason, resp.text)
+            raise ApiConnectionException(
+                self._api_url, resp.status_code, resp.reason, resp.text
+            )
 
     def __handle_initial_response(
         self, initial_response: requests.Response
@@ -350,6 +352,7 @@ class ApiClientFactory:
             return self
         elif initial_response.status_code != 401:
             raise ApiConnectionException(
+                initial_response.url,
                 initial_response.status_code,
                 initial_response.reason,
                 initial_response.text,

--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -315,7 +315,7 @@ class ApiClientFactory:
             return True
         else:
             raise ApiConnectionException(
-                self._api_url, resp.status_code, resp.reason, resp.text
+                resp.status_code, resp.reason, resp.text, self._api_url
             )
 
     def __handle_initial_response(
@@ -352,10 +352,10 @@ class ApiClientFactory:
             return self
         elif initial_response.status_code != 401:
             raise ApiConnectionException(
-                initial_response.url,
                 initial_response.status_code,
                 initial_response.reason,
                 initial_response.text,
+                initial_response.url,
             )
         else:
             return None

--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -314,9 +314,7 @@ class ApiClientFactory:
         if 200 <= resp.status_code < 300:
             return True
         else:
-            raise ApiConnectionException(
-                resp.status_code, resp.reason, resp.text, self._api_url
-            )
+            raise ApiConnectionException(resp)
 
     def __handle_initial_response(
         self, initial_response: requests.Response
@@ -351,12 +349,7 @@ class ApiClientFactory:
             self._configured = True
             return self
         elif initial_response.status_code != 401:
-            raise ApiConnectionException(
-                initial_response.status_code,
-                initial_response.reason,
-                initial_response.text,
-                initial_response.url,
-            )
+            raise ApiConnectionException(initial_response)
         else:
             return None
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -25,6 +25,8 @@ def test_api_connection_exception_repr():
     api_connection_exception = ApiConnectionException(response)
     assert all([str(v) in str(api_connection_exception) for v in args.values()])
 
+    assert repr(response) in repr(api_connection_exception)
+
 
 def test_api_exception_repr():
     status_code = 404

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -14,7 +14,7 @@ def test_api_connection_exception_repr():
     message = "You do not have permission to access this resource"
 
     api_connection_exception = ApiConnectionException(
-        url, status_code, reason_phrase, message
+        status_code, reason_phrase, message, url
     )
 
     exception_text = str(api_connection_exception)
@@ -29,7 +29,7 @@ def test_api_connection_exception_repr():
     assert type(exception_from_repr) == type(api_connection_exception)
     assert exception_from_repr.status_code == api_connection_exception.status_code
     assert exception_from_repr.reason_phrase == api_connection_exception.reason_phrase
-    assert exception_from_repr.content == api_connection_exception.content
+    assert exception_from_repr.message == api_connection_exception.message
 
 
 def test_api_exception_repr():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,8 @@
 import uuid
 
 import pytest
+import requests
+from requests_mock import Mocker
 from requests.utils import CaseInsensitiveDict
 
 from ansys.openapi.common import ApiException, ApiConnectionException
@@ -8,28 +10,20 @@ from ansys.openapi.common._exceptions import AuthenticationWarning
 
 
 def test_api_connection_exception_repr():
-    url = "http://protected.url/path/to/resource"
-    status_code = 403
-    reason_phrase = "Forbidden"
-    message = "You do not have permission to access this resource"
+    args = {
+        "url": "http://protected.url/path/to/resource",
+        "status_code": 403,
+        "reason": "Forbidden",
+        "text": "You do not have permission to access this resource",
+    }
 
-    api_connection_exception = ApiConnectionException(
-        status_code, reason_phrase, message, url
-    )
+    with Mocker() as m:
+        m.get(**args)
+        response = requests.get(args["url"])
 
-    exception_text = str(api_connection_exception)
-
-    assert url in exception_text
-    assert str(status_code) in exception_text
-    assert reason_phrase in exception_text
-    assert message in exception_text
-
-    exception_repr = api_connection_exception.__repr__()
-    exception_from_repr = eval(exception_repr)
-    assert type(exception_from_repr) == type(api_connection_exception)
-    assert exception_from_repr.status_code == api_connection_exception.status_code
-    assert exception_from_repr.reason_phrase == api_connection_exception.reason_phrase
-    assert exception_from_repr.message == api_connection_exception.message
+    assert response.status_code == args["status_code"]
+    api_connection_exception = ApiConnectionException(response)
+    assert all([str(v) in str(api_connection_exception) for v in args.values()])
 
 
 def test_api_exception_repr():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -8,20 +8,28 @@ from ansys.openapi.common._exceptions import AuthenticationWarning
 
 
 def test_api_connection_exception_repr():
+    url = "http://protected.url/path/to/resource"
     status_code = 403
     reason_phrase = "Forbidden"
     message = "You do not have permission to access this resource"
 
     api_connection_exception = ApiConnectionException(
-        status_code, reason_phrase, message
+        url, status_code, reason_phrase, message
     )
-    exception_repr = api_connection_exception.__repr__()
 
+    exception_text = str(api_connection_exception)
+
+    assert url in exception_text
+    assert str(status_code) in exception_text
+    assert reason_phrase in exception_text
+    assert message in exception_text
+
+    exception_repr = api_connection_exception.__repr__()
     exception_from_repr = eval(exception_repr)
     assert type(exception_from_repr) == type(api_connection_exception)
     assert exception_from_repr.status_code == api_connection_exception.status_code
     assert exception_from_repr.reason_phrase == api_connection_exception.reason_phrase
-    assert exception_from_repr.message == api_connection_exception.message
+    assert exception_from_repr.content == api_connection_exception.content
 
 
 def test_api_exception_repr():

--- a/tests/test_integration_basic.py
+++ b/tests/test_integration_basic.py
@@ -71,8 +71,8 @@ class TestBasic:
         client_factory = ApiClientFactory(TEST_URL, SessionConfiguration())
         with pytest.raises(ApiConnectionException) as exception_info:
             _ = client_factory.with_credentials("eve", "password").connect()
-        assert exception_info.value.status_code == 401
-        assert "Unauthorized" in exception_info.value.reason_phrase
+        assert exception_info.value.response.status_code == 401
+        assert "Unauthorized" in exception_info.value.response.reason
 
     def test_get_health_returns_200_ok(self):
         client_factory = ApiClientFactory(TEST_URL, SessionConfiguration())

--- a/tests/test_integration_negotiate.py
+++ b/tests/test_integration_negotiate.py
@@ -137,5 +137,5 @@ class TestNegotiateFailures:
         client_factory = ApiClientFactory(TEST_URL, SessionConfiguration())
         with pytest.raises(ApiConnectionException) as excinfo:
             _ = client_factory.with_autologon().connect()
-        assert excinfo.value.status_code == 403
-        assert excinfo.value.reason_phrase == "Forbidden"
+        assert excinfo.value.response.status_code == 403
+        assert excinfo.value.response.reason == "Forbidden"

--- a/tests/test_session_creation.py
+++ b/tests/test_session_creation.py
@@ -40,8 +40,8 @@ def test_other_status_codes_throw(status_code, reason_phrase):
         m.get(SERVICELAYER_URL, status_code=status_code, reason=reason_phrase)
         with pytest.raises(ApiConnectionException) as excinfo:
             _ = ApiClientFactory(SERVICELAYER_URL).with_anonymous()
-        assert excinfo.value.status_code == status_code
-        assert excinfo.value.reason_phrase == reason_phrase
+        assert excinfo.value.response.status_code == status_code
+        assert excinfo.value.response.reason == reason_phrase
 
 
 def test_missing_www_authenticate_throws():
@@ -123,8 +123,8 @@ def test_throws_with_invalid_credentials():
             _ = ApiClientFactory(SERVICELAYER_URL).with_credentials(
                 username="NOT_A_TEST_USER", password="PASSWORD"
             )
-        assert exception_info.value.status_code == 401
-        assert exception_info.value.reason_phrase == UNAUTHORIZED
+        assert exception_info.value.response.status_code == 401
+        assert exception_info.value.response.reason == UNAUTHORIZED
 
 
 def wrap_with_workstation(func):

--- a/tests/test_session_creation.py
+++ b/tests/test_session_creation.py
@@ -4,6 +4,7 @@ from functools import wraps
 from urllib.parse import parse_qs
 
 import pytest
+import requests
 import requests_mock
 import requests_ntlm
 
@@ -387,3 +388,15 @@ def test_no_oidc_throws():
 
 def test_self_signed_throws():
     pass
+
+
+def test_invalid_initial_response_raises_exception():
+    factory = ApiClientFactory(SERVICELAYER_URL)
+    with requests_mock.Mocker() as m:
+        m.get(
+            SERVICELAYER_URL,
+            status_code=404,
+        )
+        resp = requests.get(SERVICELAYER_URL)
+    with pytest.raises(ApiConnectionException, match=rf".*{SERVICELAYER_URL}.*404.*"):
+        factory._ApiClientFactory__handle_initial_response(resp)


### PR DESCRIPTION
Closes #313 

Improves the message included in an ApiConnectionException to include all the information that is passed into the exception constructor, instead of just the response from the server.

Also adds the URL that resulted in the exception, resulting in a stack trace that looks like this:

```
Traceback (most recent call last):
  File "C:\Users\<username>\AppData\Roaming\JetBrains\PyCharm2022.2\scratches\scratch_5.py", line 6, in <module>
    conn = ApiClientFactory(api_url=url).with_credentials(**creds).connect()
  File "C:\git\pyansys\openapi-common\src\ansys\openapi\common\_session.py", line 213, in with_credentials
    if self.__test_connection():
  File "C:\git\pyansys\openapi-common\src\ansys\openapi\common\_session.py", line 317, in __test_connection
    raise ApiConnectionException(
ansys.openapi.common._exceptions.ApiConnectionException: Request url 'http://hostname/invalid/path' failed with reason 404: Not Found.
The following was returned by the server:
<!DOCTYPE html>
<html>
...
```

In some cases the content returned by the server would have been enough to figure out the cause of the issue, but not always. We now always raise an exception with at least the following:

* url
* status code
* reason phrase

If any content was returned by the server, it is also included in the exception.