### PR TITLE
Fix ApiConnectionException docstring

### DIFF
--- a/src/ansys/openapi/common/_exceptions.py
+++ b/src/ansys/openapi/common/_exceptions.py
@@ -10,7 +10,7 @@ if MYPY:
 class ApiConnectionException(Exception):
     """
     Provides the exception to raise when connection to the API server fails. For more information
-    about the failure, inspect ``.status_code`` and ``.reason_phrase``.
+    about the failure, inspect ``.response``.
 
     Attributes
     ----------


### PR DESCRIPTION
In PR #316 we changed the structure of the ApiConnectionException, but we did not change the docstring.

This PR changes the docstring to reflect the changes to the class.