### PR TITLE
CI - Remove JSON docs publishing

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -156,35 +156,6 @@ jobs:
           sudo apt-get install -y texlive-latex-extra latexmk texlive-xetex fonts-freefont-otf xindy
           make -C doc latexpdf
 
-      - name: Build json documentation
-        run: |
-          # Export the documentation files to JSON files.
-          poetry run sphinx-build -M json doc/source doc-json -j auto -w build_errors.txt -N;
-
-      - name: Flatten the generated nested files into a single directory
-        run: |
-          echo Flattening a nested directory
-          mkdir doc-flatten-json;
-          echo Move all the JSON file to the flatten directory.
-          find . -name "*.fjson" -exec mv "{}" --backup=numbered ./doc-flatten-json \;
-          echo Make sure all the file has .json extensions instead of the .fjson
-          for file in doc-flatten-json/*.fjson ; do mv -- "$file" "${file%.fjson}.json" ; done;
-
-      - name: zip the flattened JSON directory
-        run: |
-          zip -r openapi-common-doc-flatten-json.zip doc-flatten-json;
-          mkdir openapi-common-doc-flatten-json;
-          mv openapi-common-doc-flatten-json.zip openapi-common-doc-flatten-json;
-          echo "Clean up build directories after the process is completed."
-          rm -rf doc-json doc-flatten-json;
-
-      - name: Upload json Documentation
-        uses: actions/upload-artifact@v3
-        with:
-          name: openapi-common-doc-flatten-json.zip
-          path: openapi-common-doc-flatten-json
-          retention-days: 7
-
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Closes #326 

This PR removes the docs build for JSON format, this should unblock the sphinx-theme update, as well as removing some magic bash scripts.