### PR TITLE
CI - Workaround for pydata-sphinx-theme invalid wheel

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -145,6 +145,7 @@ jobs:
       - name: Install library
         run: |
           pip install poetry
+          poetry config installer.modern-installation false
           poetry install --with docs --extras "oidc linux-kerberos"
 
       - name: Build HTML


### PR DESCRIPTION
Recent update to poetry has switched to a new "modern" installer. This strictly validates package compliance to PEP-627 and ensures that every file other than optional `.pyc` and the `RECORD` file have correct hashes.

Unfortunately for use `sphinx-theme-builder` currently fills this file with nonsense hashes when generating the theme files for `pydata-sphinx-theme` and so poetry is refusing to install it. I have some sympathy with the poetry devs, unlike the rather rude contributor who made the upstream fix, however this seems to not be a release priority for the maintainer of `sphinx-theme-builder`.

This PR makes the workaround of reverting to the old installer in the one CI step where we actually use this dependency.